### PR TITLE
fix: cannot unmarshal number 3.1 into Go struct field FileDownloadUrl.url.client of type int

### DIFF
--- a/pkg/driver/download.go
+++ b/pkg/driver/download.go
@@ -11,9 +11,9 @@ import (
 )
 
 type FileDownloadUrl struct {
-	Client int    `json:"client"`
-	OSSID  string `json:"oss_id"`
-	Url    string `json:"url"`
+	Client float64 `json:"client"`
+	OSSID  string  `json:"oss_id"`
+	Url    string  `json:"url"`
 }
 
 type DownloadInfo struct {


### PR DESCRIPTION
related: 
- alist-org/alist#5117