### PR TITLE
feat(dir): support concurrent for `List`

### DIFF
--- a/pkg/driver/dir.go
+++ b/pkg/driver/dir.go
@@ -1,6 +1,8 @@
 package driver
 
 import (
+	"sync"
+
 	"github.com/go-resty/resty/v2"
 )
 
@@ -28,6 +30,63 @@ func (c *Pan115Client) Mkdir(parentID string, name string) (string, error) {
 // List list all files and directories
 func (c *Pan115Client) List(dirID string) (*[]File, error) {
 	return c.ListWithLimit(dirID, FileListLimit)
+}
+
+// ListWithMultiThreads list all files and directories more faster
+func (c *Pan115Client) ListWithMultiThreads(dirID string, limit int64) (*[]File, error) {
+	var files []File
+	offset := int64(0)
+	req := c.NewRequest().ForceContentType("application/json;charset=UTF-8")
+	result, err := GetFiles(req, dirID, WithLimit(limit), WithOffset(offset))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, fileInfo := range result.Files {
+		files = append(files, *(&File{}).from(&fileInfo))
+	}
+	offset = int64(result.Offset) + limit
+
+	if offset >= int64(result.Count) {
+		return &files, nil
+	}
+
+	remainingCount := (int64(result.Count) - limit)
+	jobCount := remainingCount / limit
+	lastPageLimit := remainingCount % limit
+
+	if lastPageLimit != 0 {
+		jobCount += 1
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(int(jobCount))
+
+	noOrderFiles := make(map[int]*[]File)
+
+	for i := 0; i < int(jobCount); i++ {
+		go func(_offset int64, jobIndex int, done func()) {
+			defer done()
+
+			pageFiles, err := c.ListPage(dirID, _offset, limit)
+			if err != nil {
+				return
+			}
+			noOrderFiles[jobIndex] = pageFiles
+
+		}(offset+limit*int64(i), i, wg.Done)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < int(jobCount); i++ {
+		pageFiles, exists := noOrderFiles[i]
+		if exists {
+			files = append(files, *pageFiles...)
+		}
+	}
+
+	return &files, nil
 }
 
 // ListWithLimit list all files and directories with limit


### PR DESCRIPTION
新增 `ListWithMultiThreads` 方法，更快获取文件夹内容

获取文件夹下的 2967 个文件列表，正常循环大概需要十多秒，并发获取不到一秒