### PR TITLE
fix(driver): handle decimal space info sizes

### DIFF
--- a/pkg/driver/info.go
+++ b/pkg/driver/info.go
@@ -1,5 +1,11 @@
 package driver
 
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
 // GetInfo get space info and login device info.
 func (c *Pan115Client) GetInfo() (InfoData, error) {
 	result := InfoResponse{}
@@ -31,14 +37,78 @@ type TotalSize struct {
 	SizeFormat string `json:"size_format"`
 }
 
+func (s *TotalSize) UnmarshalJSON(b []byte) error {
+	size, sizeFormat, err := unmarshalSpaceSize(b)
+	if err != nil {
+		return err
+	}
+	s.Size = size
+	s.SizeFormat = sizeFormat
+	return nil
+}
+
 type RemainSize struct {
 	Size       int64  `json:"size"`
 	SizeFormat string `json:"size_format"`
 }
 
+func (s *RemainSize) UnmarshalJSON(b []byte) error {
+	size, sizeFormat, err := unmarshalSpaceSize(b)
+	if err != nil {
+		return err
+	}
+	s.Size = size
+	s.SizeFormat = sizeFormat
+	return nil
+}
+
 type UseSize struct {
 	Size       int64  `json:"size"`
 	SizeFormat string `json:"size_format"`
+}
+
+func (s *UseSize) UnmarshalJSON(b []byte) error {
+	size, sizeFormat, err := unmarshalSpaceSize(b)
+	if err != nil {
+		return err
+	}
+	s.Size = size
+	s.SizeFormat = sizeFormat
+	return nil
+}
+
+func unmarshalSpaceSize(b []byte) (int64, string, error) {
+	var raw struct {
+		Size       json.RawMessage `json:"size"`
+		SizeFormat string          `json:"size_format"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return 0, "", err
+	}
+	size, err := parseSpaceSize(raw.Size)
+	if err != nil {
+		return 0, "", err
+	}
+	return size, raw.SizeFormat, nil
+}
+
+func parseSpaceSize(b []byte) (int64, error) {
+	if len(b) == 0 || string(b) == "null" {
+		return 0, nil
+	}
+	var value string
+	if b[0] == '"' {
+		if err := json.Unmarshal(b, &value); err != nil {
+			return 0, err
+		}
+	} else {
+		value = string(b)
+	}
+	value = strings.TrimSpace(value)
+	if dot := strings.IndexByte(value, '.'); dot >= 0 {
+		value = value[:dot]
+	}
+	return strconv.ParseInt(value, 10, 64)
 }
 
 type SpaceInfo struct {

--- a/pkg/driver/info_test.go
+++ b/pkg/driver/info_test.go
@@ -1,0 +1,30 @@
+package driver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInfoResponseUnmarshalsDecimalSpaceSizes(t *testing.T) {
+	const payload = `{
+		"state": true,
+		"data": {
+			"space_info": {
+				"all_total": {"size": 155555555555555.25, "size_format": "141.49TB"},
+				"all_remain": {"size": "123.75", "size_format": "123B"},
+				"all_use": {"size": 42, "size_format": "42B"}
+			},
+			"login_devices_info": {},
+			"imei_info": false
+		}
+	}`
+
+	var resp InfoResponse
+	require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+	assert.Equal(t, int64(155555555555555), resp.Data.SpaceInfo.AllTotal.Size)
+	assert.Equal(t, int64(123), resp.Data.SpaceInfo.AllRemain.Size)
+	assert.Equal(t, int64(42), resp.Data.SpaceInfo.AllUse.Size)
+}


### PR DESCRIPTION
## Summary
- Add custom JSON unmarshalling for 115 space size responses that may contain decimal numbers.
- Keep public size fields as int64 while accepting decimal numeric and string payloads.
- Add regression coverage for decimal `space_info` sizes.

## Source
- Reported from OpenList issue: https://github.com/OpenListTeam/OpenList/issues/2343

## Test Plan
- [x] `git diff --check`
- [x] `go test ./pkg/driver -run TestInfoResponseUnmarshalsDecimalSpaceSizes -count=1`
- [x] `go test ./... -run TestInfoResponseUnmarshalsDecimalSpaceSizes -count=1`

## Notes
- `go test ./...` without filtering currently requires a valid 115 `COOKIE`; with an empty cookie it fails existing integration tests with `bad cookie` / `user not login`.