### PR TITLE
fix(driver): parse exponent space info sizes

### DIFF
--- a/pkg/driver/info.go
+++ b/pkg/driver/info.go
@@ -114,6 +114,9 @@ func parseSpaceSize(b []byte) (int64, error) {
 		return 0, err
 	}
 	sizeInt, _ := size.Int(nil)
+	if sizeInt == nil {
+		return 0, strconv.ErrRange
+	}
 	if !sizeInt.IsInt64() {
 		return 0, strconv.ErrRange
 	}

--- a/pkg/driver/info.go
+++ b/pkg/driver/info.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"encoding/json"
 	"math/big"
+	"strconv"
 	"strings"
 )
 
@@ -113,6 +114,9 @@ func parseSpaceSize(b []byte) (int64, error) {
 		return 0, err
 	}
 	sizeInt, _ := size.Int(nil)
+	if !sizeInt.IsInt64() {
+		return 0, strconv.ErrRange
+	}
 	return sizeInt.Int64(), nil
 }
 

--- a/pkg/driver/info.go
+++ b/pkg/driver/info.go
@@ -2,7 +2,7 @@ package driver
 
 import (
 	"encoding/json"
-	"strconv"
+	"math/big"
 	"strings"
 )
 
@@ -105,10 +105,15 @@ func parseSpaceSize(b []byte) (int64, error) {
 		value = string(b)
 	}
 	value = strings.TrimSpace(value)
-	if dot := strings.IndexByte(value, '.'); dot >= 0 {
-		value = value[:dot]
+	if value == "" {
+		return 0, nil
 	}
-	return strconv.ParseInt(value, 10, 64)
+	size, _, err := big.ParseFloat(value, 10, 256, big.ToZero)
+	if err != nil {
+		return 0, err
+	}
+	sizeInt, _ := size.Int(nil)
+	return sizeInt.Int64(), nil
 }
 
 type SpaceInfo struct {

--- a/pkg/driver/info_test.go
+++ b/pkg/driver/info_test.go
@@ -28,3 +28,24 @@ func TestInfoResponseUnmarshalsDecimalSpaceSizes(t *testing.T) {
 	assert.Equal(t, int64(123), resp.Data.SpaceInfo.AllRemain.Size)
 	assert.Equal(t, int64(42), resp.Data.SpaceInfo.AllUse.Size)
 }
+
+func TestInfoResponseUnmarshalsExponentSpaceSizes(t *testing.T) {
+	const payload = `{
+		"state": true,
+		"data": {
+			"space_info": {
+				"all_total": {"size": 1.5e6, "size_format": "1.43MB"},
+				"all_remain": {"size": "2.5e3", "size_format": "2.44KB"},
+				"all_use": {"size": 42, "size_format": "42B"}
+			},
+			"login_devices_info": {},
+			"imei_info": false
+		}
+	}`
+
+	var resp InfoResponse
+	require.NoError(t, json.Unmarshal([]byte(payload), &resp))
+	assert.Equal(t, int64(1500000), resp.Data.SpaceInfo.AllTotal.Size)
+	assert.Equal(t, int64(2500), resp.Data.SpaceInfo.AllRemain.Size)
+	assert.Equal(t, int64(42), resp.Data.SpaceInfo.AllUse.Size)
+}

--- a/pkg/driver/info_test.go
+++ b/pkg/driver/info_test.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +49,24 @@ func TestInfoResponseUnmarshalsExponentSpaceSizes(t *testing.T) {
 	assert.Equal(t, int64(1500000), resp.Data.SpaceInfo.AllTotal.Size)
 	assert.Equal(t, int64(2500), resp.Data.SpaceInfo.AllRemain.Size)
 	assert.Equal(t, int64(42), resp.Data.SpaceInfo.AllUse.Size)
+}
+
+func TestInfoResponseRejectsOutOfRangeSpaceSizes(t *testing.T) {
+	const payload = `{
+		"state": true,
+		"data": {
+			"space_info": {
+				"all_total": {"size": 1e19, "size_format": "9.09EB"},
+				"all_remain": {"size": 0, "size_format": "0B"},
+				"all_use": {"size": 42, "size_format": "42B"}
+			},
+			"login_devices_info": {},
+			"imei_info": false
+		}
+	}`
+
+	var resp InfoResponse
+	err := json.Unmarshal([]byte(payload), &resp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, strconv.ErrRange)
 }

--- a/pkg/driver/info_test.go
+++ b/pkg/driver/info_test.go
@@ -70,3 +70,21 @@ func TestInfoResponseRejectsOutOfRangeSpaceSizes(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, strconv.ErrRange)
 }
+
+func TestInfoResponseRejectsInfiniteSpaceSizes(t *testing.T) {
+	const payload = `{
+		"state": true,
+		"data": {
+			"space_info": {
+				"all_total": {"size": "Inf", "size_format": "Inf"},
+				"all_remain": {"size": 0, "size_format": "0B"},
+				"all_use": {"size": 42, "size_format": "42B"}
+			},
+			"login_devices_info": {},
+			"imei_info": false
+		}
+	}`
+
+	var resp InfoResponse
+	require.Error(t, json.Unmarshal([]byte(payload), &resp))
+}


### PR DESCRIPTION
## Summary
- Address Codex review feedback from #74 by parsing exponent-form space size values correctly.
- Replace manual decimal truncation with high-precision numeric parsing and integer truncation.
- Add regression coverage for numeric and string exponent payloads.

## Source
- Follow-up to Codex review on #74: https://github.com/SheltonZhu/115driver/pull/74#discussion_r3290101150
- Original issue source: https://github.com/OpenListTeam/OpenList/issues/2343

## Test Plan
- [x] `go test ./pkg/driver -run 'TestInfoResponseUnmarshals(Decimal|Exponent)SpaceSizes' -count=1`\n- [x] `git diff --check`\n- [x] `go test ./... -run 'TestInfoResponseUnmarshals(Decimal|Exponent)SpaceSizes' -count=1`