### PR TITLE
feat(account): expose account info in cli and mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ go install github.com/SheltonZhu/115driver/cmd/115driver@latest
 
 # Verify identity
 115driver whoami
+
+# Account and storage info
+115driver info
 ```
 
 Credentials are stored in `~/.115driver/config.toml` and support multiple profiles.
@@ -177,6 +180,9 @@ Additional env vars: `DRIVER115_CONFIG` (config path), `DRIVER115_PROFILE` (prof
 
 # File info
 115driver stat /path/to/file
+
+# Account and storage info
+115driver info
 
 # Create directories
 115driver mkdir /new/dir
@@ -211,6 +217,7 @@ All commands support `--json` for machine-readable output:
 ```bash
 115driver --json ls /path/to/dir
 115driver --json stat /path/to/file
+115driver --json info
 ```
 
 ### Shell Completion
@@ -260,6 +267,7 @@ mcp --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx"
 
 | Category | Tools |
 |----------|-------|
+| **Account** | `getAccountInfo` |
 | **Directory** | `listDirectory` |
 | **File** | `stat`, `mkdir`, `delete`, `rename`, `move`, `copy`, `upload_from_url`, `upload_from_local`, `download_file`, `get_download_info` |
 | **Search** | `search` |
@@ -319,12 +327,13 @@ The 115 API may have rate limits. If you encounter rate limiting errors:
 ├── cli/                      # CLI implementation
 │   ├── cmd/                  # Cobra commands
 │   └── internal/             # Internal packages (auth, output, resolver)
+├── internal/                 # Shared app-level helpers
 ├── pkg/
 │   ├── driver/               # Core driver (client, login, file, upload, download, search, share, offline)
 │   └── crypto/               # Cryptography utilities (ECDH, AES, RSA)
 └── mcp/                      # MCP server (stdin/stdout JSON-RPC 2.0)
     ├── main.go               # Entry point
-    └── server/tools/         # Tool implementations (dir, file, search, offline, share, recycle)
+    └── server/tools/         # Tool implementations (account, dir, file, search, offline, share, recycle)
 ```
 
 ## Star History

--- a/cli/cmd/info.go
+++ b/cli/cmd/info.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/SheltonZhu/115driver/cli/internal/output"
+	"github.com/SheltonZhu/115driver/internal/accountinfo"
+	"github.com/spf13/cobra"
+)
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Show current account and storage info",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		userInfo, err := client.GetUser()
+		if err != nil {
+			return &exitError{code: output.ExitAuth, msg: fmt.Sprintf("Failed to get user info: %v", err)}
+		}
+		info, err := client.GetInfo()
+		if err != nil {
+			return &exitError{code: output.ExitError, msg: fmt.Sprintf("Failed to get account info: %v", err)}
+		}
+
+		account := accountinfo.FromDriverData(userInfo, info)
+		if jsonOutput {
+			printer.PrintSuccess(account)
+		} else {
+			fmt.Print(formatAccountInfoText(account))
+		}
+		return nil
+	},
+}
+
+func formatAccountInfoText(info accountinfo.AccountInfo) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "User ID:  %d\n", info.User.UserID)
+	fmt.Fprintf(&b, "Username: %s\n", info.User.Username)
+	if info.User.VIP > 0 {
+		fmt.Fprintf(&b, "VIP:      %d (expires: %d)\n", info.User.VIP, info.User.Expire)
+	}
+	fmt.Fprintln(&b, "Space:")
+	fmt.Fprintf(&b, "  Total:    %s\n", formatSpaceSize(info.Space.Total))
+	fmt.Fprintf(&b, "  Remain:   %s\n", formatSpaceSize(info.Space.Remain))
+	fmt.Fprintf(&b, "  Used:     %s\n", formatSpaceSize(info.Space.Used))
+	if info.LoginDevices.Last.Device != "" || info.LoginDevices.Last.IP != "" {
+		fmt.Fprintf(&b, "Last Login: %s %s %s\n", info.LoginDevices.Last.Device, info.LoginDevices.Last.IP, info.LoginDevices.Last.City)
+	}
+	return b.String()
+}
+
+func formatSpaceSize(size accountinfo.SizeInfo) string {
+	if size.SizeFormat != "" {
+		return fmt.Sprintf("%s (%d bytes)", size.SizeFormat, size.Size)
+	}
+	return fmt.Sprintf("%s (%d bytes)", output.FormatFileSize(size.Size), size.Size)
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+}

--- a/cli/cmd/info_test.go
+++ b/cli/cmd/info_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SheltonZhu/115driver/internal/accountinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatAccountInfoText(t *testing.T) {
+	info := accountinfo.AccountInfo{
+		User: accountinfo.User{
+			UserID:   12345,
+			Username: "alice",
+			VIP:      1,
+			Expire:   1770000000,
+		},
+		Space: accountinfo.Space{
+			Total:  accountinfo.SizeInfo{Size: 1000, SizeFormat: "1000B"},
+			Remain: accountinfo.SizeInfo{Size: 250, SizeFormat: "250B"},
+			Used:   accountinfo.SizeInfo{Size: 750, SizeFormat: "750B"},
+		},
+	}
+
+	got := formatAccountInfoText(info)
+
+	assert.True(t, strings.Contains(got, "User ID:  12345"))
+	assert.True(t, strings.Contains(got, "Username: alice"))
+	assert.True(t, strings.Contains(got, "VIP:      1 (expires: 1770000000)"))
+	assert.True(t, strings.Contains(got, "Total:    1000B (1000 bytes)"))
+	assert.True(t, strings.Contains(got, "Remain:   250B (250 bytes)"))
+	assert.True(t, strings.Contains(got, "Used:     750B (750 bytes)"))
+}

--- a/internal/accountinfo/accountinfo.go
+++ b/internal/accountinfo/accountinfo.go
@@ -1,0 +1,58 @@
+package accountinfo
+
+import "github.com/SheltonZhu/115driver/pkg/driver"
+
+type AccountInfo struct {
+	User         User                    `json:"user"`
+	Space        Space                   `json:"space"`
+	LoginDevices driver.LoginDevicesInfo `json:"login_devices"`
+	ImeiInfo     bool                    `json:"imei_info"`
+}
+
+type User struct {
+	UserID   int64  `json:"user_id"`
+	Username string `json:"username"`
+	VIP      int    `json:"vip"`
+	Expire   int    `json:"expire"`
+}
+
+type Space struct {
+	Total  SizeInfo `json:"total"`
+	Remain SizeInfo `json:"remain"`
+	Used   SizeInfo `json:"used"`
+}
+
+type SizeInfo struct {
+	Size       int64  `json:"size"`
+	SizeFormat string `json:"size_format"`
+}
+
+func FromDriverData(user *driver.UserInfo, info driver.InfoData) AccountInfo {
+	account := AccountInfo{
+		Space: Space{
+			Total: SizeInfo{
+				Size:       info.SpaceInfo.AllTotal.Size,
+				SizeFormat: info.SpaceInfo.AllTotal.SizeFormat,
+			},
+			Remain: SizeInfo{
+				Size:       info.SpaceInfo.AllRemain.Size,
+				SizeFormat: info.SpaceInfo.AllRemain.SizeFormat,
+			},
+			Used: SizeInfo{
+				Size:       info.SpaceInfo.AllUse.Size,
+				SizeFormat: info.SpaceInfo.AllUse.SizeFormat,
+			},
+		},
+		LoginDevices: info.LoginDevicesInfo,
+		ImeiInfo:     info.ImeiInfo,
+	}
+	if user != nil {
+		account.User = User{
+			UserID:   user.UserID,
+			Username: user.UserName,
+			VIP:      user.Vip,
+			Expire:   user.Expire,
+		}
+	}
+	return account
+}

--- a/internal/accountinfo/accountinfo_test.go
+++ b/internal/accountinfo/accountinfo_test.go
@@ -1,0 +1,45 @@
+package accountinfo
+
+import (
+	"testing"
+
+	"github.com/SheltonZhu/115driver/pkg/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromDriverDataMapsAccountInfo(t *testing.T) {
+	user := &driver.UserInfo{
+		UserID:   12345,
+		UserName: "alice",
+		Vip:      1,
+		Expire:   1770000000,
+	}
+	info := driver.InfoData{
+		SpaceInfo: driver.SpaceInfo{
+			AllTotal:  driver.TotalSize{Size: 1000, SizeFormat: "1000B"},
+			AllRemain: driver.RemainSize{Size: 250, SizeFormat: "250B"},
+			AllUse:    driver.UseSize{Size: 750, SizeFormat: "750B"},
+		},
+		LoginDevicesInfo: driver.LoginDevicesInfo{
+			Last: driver.LastDevice{IP: "127.0.0.1", Device: "Browser"},
+			List: []driver.Device{
+				{Device: "Browser", IsCurrent: 1},
+			},
+		},
+		ImeiInfo: true,
+	}
+
+	got := FromDriverData(user, info)
+
+	assert.Equal(t, int64(12345), got.User.UserID)
+	assert.Equal(t, "alice", got.User.Username)
+	assert.Equal(t, 1, got.User.VIP)
+	assert.Equal(t, 1770000000, got.User.Expire)
+	assert.Equal(t, int64(1000), got.Space.Total.Size)
+	assert.Equal(t, "1000B", got.Space.Total.SizeFormat)
+	assert.Equal(t, int64(250), got.Space.Remain.Size)
+	assert.Equal(t, int64(750), got.Space.Used.Size)
+	assert.Equal(t, "127.0.0.1", got.LoginDevices.Last.IP)
+	assert.Len(t, got.LoginDevices.List, 1)
+	assert.True(t, got.ImeiInfo)
+}

--- a/mcp/mcp_example.md
+++ b/mcp/mcp_example.md
@@ -20,6 +20,12 @@ The server will listen on stdin/stdout for MCP requests.
 
 ## Available Tools
 
+### Account Tools
+
+1. `getAccountInfo`: Get current account, storage space, and login device info
+   - Parameters: none
+   - Returns: `user`, `space.total`, `space.remain`, `space.used`, `login_devices`, and `imei_info`
+
 ### Directory Tools
 
 1. `listDirectory`: List files and directories in a specific directory

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -46,6 +46,10 @@ func (s *Server) Start(ctx context.Context) error {
 
 // registerTools registers all available tools with the MCP server
 func (s *Server) registerTools() {
+	// Register account tools
+	accountTools := tools.NewAccountTools(s.client)
+	accountTools.RegisterTools(s.mcpServer)
+
 	// Register directory tools
 	dirTools := tools.NewDirTools(s.client)
 	dirTools.RegisterTools(s.mcpServer)

--- a/mcp/server/tools/account.go
+++ b/mcp/server/tools/account.go
@@ -1,0 +1,81 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/SheltonZhu/115driver/internal/accountinfo"
+	"github.com/SheltonZhu/115driver/pkg/driver"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type AccountTools struct {
+	client *driver.Pan115Client
+}
+
+func NewAccountTools(client *driver.Pan115Client) *AccountTools {
+	return &AccountTools{
+		client: client,
+	}
+}
+
+func (at *AccountTools) RegisterTools(server *mcp.Server) {
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "getAccountInfo",
+		Description: "Get current account, storage space, and login device info",
+	}, at.getAccountInfo)
+}
+
+func (at *AccountTools) getAccountInfo(ctx context.Context, req *mcp.CallToolRequest, args struct{}) (*mcp.CallToolResult, any, error) {
+	userInfo, err := at.client.GetUser()
+	if err != nil {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: fmt.Sprintf("Failed to get user info: %v", err),
+				},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+	info, err := at.client.GetInfo()
+	if err != nil {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: fmt.Sprintf("Failed to get account info: %v", err),
+				},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	responseJSON, err := marshalAccountInfoResult(accountinfo.FromDriverData(userInfo, info))
+	if err != nil {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: fmt.Sprintf("Failed to serialize account info: %v", err),
+				},
+			},
+			IsError: true,
+		}, nil, nil
+	}
+
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{
+				Text: responseJSON,
+			},
+		},
+	}, nil, nil
+}
+
+func marshalAccountInfoResult(info accountinfo.AccountInfo) (string, error) {
+	responseJSON, err := json.Marshal(info)
+	if err != nil {
+		return "", err
+	}
+	return string(responseJSON), nil
+}

--- a/mcp/server/tools/account_test.go
+++ b/mcp/server/tools/account_test.go
@@ -1,0 +1,34 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/SheltonZhu/115driver/internal/accountinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalAccountInfoResult(t *testing.T) {
+	info := accountinfo.AccountInfo{
+		User: accountinfo.User{
+			UserID:   12345,
+			Username: "alice",
+		},
+		Space: accountinfo.Space{
+			Total:  accountinfo.SizeInfo{Size: 1000, SizeFormat: "1000B"},
+			Remain: accountinfo.SizeInfo{Size: 250, SizeFormat: "250B"},
+			Used:   accountinfo.SizeInfo{Size: 750, SizeFormat: "750B"},
+		},
+	}
+
+	got, err := marshalAccountInfoResult(info)
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &decoded))
+	assert.Contains(t, decoded, "user")
+	assert.Contains(t, decoded, "space")
+	assert.Contains(t, decoded, "login_devices")
+	assert.Contains(t, decoded, "imei_info")
+}


### PR DESCRIPTION
## Summary
- Add `115driver info` for account and storage space display, including JSON output support.
- Add MCP `getAccountInfo` tool returning user, space, login device, and IMEI info.
- Share account info response mapping between CLI and MCP via `internal/accountinfo`.
- Update README and MCP example docs.

## Fields
- `user`: `user_id`, `username`, `vip`, `expire`
- `space`: `total`, `remain`, `used`, each with `size` and `size_format`
- `login_devices`: last login device and device list from `GetInfo()`
- `imei_info`

## Test Plan
- [x] `git diff --check`
- [x] `go test ./internal/accountinfo ./cli/cmd ./mcp/server ./mcp/server/tools -count=1`
- [x] `go build ./cli ./mcp`
- [x] `go test ./... -run 'Test(FromDriverDataMapsAccountInfo|FormatAccountInfoText|MarshalAccountInfoResult|InfoResponseUnmarshalsDecimalSpaceSizes)' -count=1`\n\n## Notes\n- Full `go test ./...` still requires a valid 115 `COOKIE`; with an empty cookie, existing driver integration tests fail with `bad cookie` / `user not login`.