### PR TITLE
fix(mcp,cli): harden file operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ By default, the MCP server only registers read-only cloud tools plus
 Tools that create, upload, move, rename, delete, clean recycle bin items, or
 add/remove offline tasks require `--allow-destructive-tools`.
 `upload_from_url` only accepts HTTP/HTTPS URLs, rejects redirects to unsafe
-hosts, and blocks loopback/private/link-local resolved addresses.
+hosts, and blocks loopback/private/link-local resolved addresses. If a hostname
+resolves to multiple safe addresses, MCP HTTP transfers try later addresses when
+an earlier address cannot be reached.
 
 ### Available Tools
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Additional env vars: `DRIVER115_CONFIG` (config path), `DRIVER115_PROFILE` (prof
 
 # List directory contents
 115driver ls /remote/dir --limit 100 --offset 0
+# With --json, ls includes offset, limit, has_more, and next_offset.
 
 # Upload & Download
 115driver upload /local/file /remote/dir
@@ -282,6 +283,8 @@ By default, the MCP server only registers read-only cloud tools plus
 `download_file`, which requires `--local-root` before it can write locally.
 Tools that create, upload, move, rename, delete, clean recycle bin items, or
 add/remove offline tasks require `--allow-destructive-tools`.
+`upload_from_url` only accepts HTTP/HTTPS URLs, rejects redirects to unsafe
+hosts, and blocks loopback/private/link-local resolved addresses.
 
 ### Available Tools
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Additional env vars: `DRIVER115_CONFIG` (config path), `DRIVER115_PROFILE` (prof
 
 # List directory contents
 115driver ls /remote/dir --limit 100 --offset 0
+# Text output prints a next-offset hint when a page may have more entries.
 # With --json, ls includes offset, limit, has_more, and next_offset.
 
 # Upload & Download

--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ mcp --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx"
 
 By default, the MCP server only registers read-only cloud tools plus
 `download_file`, which requires `--local-root` before it can write locally.
+Local-root validation resolves existing target paths and existing parent
+directories before allowing local reads or writes, so symlinks cannot point MCP
+file tools outside the configured root.
 Tools that create, upload, move, rename, delete, clean recycle bin items, or
 add/remove offline tasks require `--allow-destructive-tools`.
 `upload_from_url` only accepts HTTP/HTTPS URLs, rejects redirects to unsafe

--- a/README.md
+++ b/README.md
@@ -193,10 +193,15 @@ Additional env vars: `DRIVER115_CONFIG` (config path), `DRIVER115_PROFILE` (prof
 115driver cp /source/file /dest/dir
 115driver rename /path/to/file new_name
 115driver rm /path/to/file
+115driver rm /path/to/dir --force      # required for directory deletes in --json mode
+
+# List directory contents
+115driver ls /remote/dir --limit 100 --offset 0
 
 # Upload & Download
 115driver upload /local/file /remote/dir
 115driver download /remote/file /local/dir
+115driver download /remote/file /local/dir --timeout 6h  # default 2h, 0 disables timeout
 
 # Search
 115driver search keyword
@@ -261,7 +266,22 @@ mcp --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx"
 
 # If built from source:
 ./115driver-mcp-server --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx"
+
+# Allow longer MCP HTTP transfers:
+./115driver-mcp-server --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx" --download-timeout=6h
+
+# Optional MCP transfer size limits:
+# download_file is unlimited by default; upload_from_url defaults to 2 GiB.
+./115driver-mcp-server --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx" --download-max-bytes=0 --url-upload-max-bytes=10737418240
+
+# Register tools that mutate 115 cloud state:
+./115driver-mcp-server --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx" --allow-destructive-tools
 ```
+
+By default, the MCP server only registers read-only cloud tools plus
+`download_file`, which requires `--local-root` before it can write locally.
+Tools that create, upload, move, rename, delete, clean recycle bin items, or
+add/remove offline tasks require `--allow-destructive-tools`.
 
 ### Available Tools
 
@@ -269,11 +289,11 @@ mcp --cookie="UID=xxx;CID=xxx;SEID=xxx;KID=xxx"
 |----------|-------|
 | **Account** | `getAccountInfo` |
 | **Directory** | `listDirectory` |
-| **File** | `stat`, `mkdir`, `delete`, `rename`, `move`, `copy`, `upload_from_url`, `upload_from_local`, `download_file`, `get_download_info` |
+| **File** | `stat`, `download_file`, `get_download_info`; with `--allow-destructive-tools`: `mkdir`, `delete`, `rename`, `move`, `copy`, `upload_from_url`, `upload_from_local` |
 | **Search** | `search` |
-| **Offline** | `listOfflineTasks`, `addOfflineTaskURIs`, `deleteOfflineTasks`, `clearOfflineTasks` |
+| **Offline** | `listOfflineTasks`; with `--allow-destructive-tools`: `addOfflineTaskURIs`, `deleteOfflineTasks`, `clearOfflineTasks` |
 | **Share** | `getShareSnap` |
-| **Recycle** | `listRecycleBin`, `revertRecycleBin`, `cleanRecycleBin` |
+| **Recycle** | `listRecycleBin`; with `--allow-destructive-tools`: `revertRecycleBin`, `cleanRecycleBin` |
 
 ### Configure with Claude Desktop
 

--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -91,14 +91,7 @@ func downloadFile(dlInfo *driver.DownloadInfo, localPath string) error {
 		return fmt.Errorf("download failed: HTTP %d", resp.StatusCode)
 	}
 
-	out, err := os.Create(localPath)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, resp.Body)
-	return err
+	return saveDownloadResponse(localPath, resp, 0)
 }
 
 func resolveDownloadTargetPath(localTarget, fileName string) string {
@@ -107,6 +100,39 @@ func resolveDownloadTargetPath(localTarget, fileName string) string {
 
 func newDownloadHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{Timeout: timeout}
+}
+
+func saveDownloadResponse(localPath string, resp *http.Response, maxBytes int64) error {
+	if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(localPath), "."+filepath.Base(localPath)+".*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	var copyErr error
+	if maxBytes > 0 {
+		limited := &io.LimitedReader{R: resp.Body, N: maxBytes + 1}
+		written, err := io.Copy(tmp, limited)
+		if err != nil {
+			copyErr = err
+		} else if written > maxBytes || limited.N == 0 {
+			copyErr = fmt.Errorf("download exceeds limit of %d bytes", maxBytes)
+		}
+	} else {
+		_, copyErr = io.Copy(tmp, resp.Body)
+	}
+	if copyErr != nil {
+		tmp.Close()
+		return copyErr
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, localPath)
 }
 
 func init() {

--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -25,6 +25,9 @@ var downloadCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		remotePath := args[0]
 		localTarget := args[1]
+		if err := validateDownloadTimeout(downloadTimeout); err != nil {
+			return &exitError{code: output.ExitArgs, msg: err.Error()}
+		}
 
 		fileID, _, err := resolver.ResolvePath(client, remotePath)
 		if err != nil {
@@ -100,6 +103,13 @@ func resolveDownloadTargetPath(localTarget, fileName string) string {
 
 func newDownloadHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{Timeout: timeout}
+}
+
+func validateDownloadTimeout(timeout time.Duration) error {
+	if timeout < 0 {
+		return fmt.Errorf("timeout must be >= 0")
+	}
+	return nil
 }
 
 func saveDownloadResponse(localPath string, resp *http.Response, maxBytes int64) error {

--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -6,12 +6,17 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/SheltonZhu/115driver/cli/internal/output"
 	"github.com/SheltonZhu/115driver/cli/internal/resolver"
 	"github.com/SheltonZhu/115driver/pkg/driver"
 	"github.com/spf13/cobra"
 )
+
+const defaultDownloadTimeout = 2 * time.Hour
+
+var downloadTimeout = defaultDownloadTimeout
 
 var downloadCmd = &cobra.Command{
 	Use:   "download <remote_path> <local_path>",
@@ -76,7 +81,7 @@ func downloadFile(dlInfo *driver.DownloadInfo, localPath string) error {
 		}
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := newDownloadHTTPClient(downloadTimeout).Do(req)
 	if err != nil {
 		return fmt.Errorf("download request: %w", err)
 	}
@@ -100,6 +105,11 @@ func resolveDownloadTargetPath(localTarget, fileName string) string {
 	return resolver.ResolveLocalDownloadPath(localTarget, fileName)
 }
 
+func newDownloadHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout}
+}
+
 func init() {
+	downloadCmd.Flags().DurationVar(&downloadTimeout, "timeout", defaultDownloadTimeout, "Download timeout, use 0 to disable")
 	rootCmd.AddCommand(downloadCmd)
 }

--- a/cli/cmd/download_test.go
+++ b/cli/cmd/download_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestResolveDownloadTargetPath_UsesExplicitFilePath(t *testing.T) {
@@ -18,5 +19,26 @@ func TestResolveDownloadTargetPath_AppendsNameForDirectoryHint(t *testing.T) {
 	want := filepath.Join("/tmp/downloads", "remote-name.mp4")
 	if got != want {
 		t.Fatalf("unexpected target path: got %q want %q", got, want)
+	}
+}
+
+func TestResolveDownloadTargetPath_TreatsNonExistingExtensionlessPathAsFile(t *testing.T) {
+	got := resolveDownloadTargetPath(filepath.Join("/tmp", "LICENSE"), "remote-name.mp4")
+	want := filepath.Join("/tmp", "LICENSE")
+	if got != want {
+		t.Fatalf("unexpected target path: got %q want %q", got, want)
+	}
+}
+
+func TestDownloadHTTPClientUsesConfiguredTimeout(t *testing.T) {
+	client := newDownloadHTTPClient(90 * time.Second)
+	if client.Timeout != 90*time.Second {
+		t.Fatalf("expected configured timeout, got %s", client.Timeout)
+	}
+}
+
+func TestDownloadHTTPClientDefaultTimeoutAllowsLargeDownloads(t *testing.T) {
+	if defaultDownloadTimeout < time.Hour {
+		t.Fatalf("expected default timeout to allow large downloads, got %s", defaultDownloadTimeout)
 	}
 }

--- a/cli/cmd/download_test.go
+++ b/cli/cmd/download_test.go
@@ -47,6 +47,18 @@ func TestDownloadHTTPClientDefaultTimeoutAllowsLargeDownloads(t *testing.T) {
 	}
 }
 
+func TestValidateDownloadTimeoutRejectsNegativeTimeout(t *testing.T) {
+	if err := validateDownloadTimeout(-time.Second); err == nil {
+		t.Fatal("expected negative timeout to be rejected")
+	}
+}
+
+func TestValidateDownloadTimeoutAllowsZeroToDisableTimeout(t *testing.T) {
+	if err := validateDownloadTimeout(0); err != nil {
+		t.Fatalf("expected zero timeout to be accepted: %v", err)
+	}
+}
+
 func TestSaveDownloadResponsePreservesExistingFileOnFailure(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "target.txt")
 	if err := os.WriteFile(target, []byte("old"), 0600); err != nil {

--- a/cli/cmd/download_test.go
+++ b/cli/cmd/download_test.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"io"
+	"net/http"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -40,5 +44,27 @@ func TestDownloadHTTPClientUsesConfiguredTimeout(t *testing.T) {
 func TestDownloadHTTPClientDefaultTimeoutAllowsLargeDownloads(t *testing.T) {
 	if defaultDownloadTimeout < time.Hour {
 		t.Fatalf("expected default timeout to allow large downloads, got %s", defaultDownloadTimeout)
+	}
+}
+
+func TestSaveDownloadResponsePreservesExistingFileOnFailure(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target.txt")
+	if err := os.WriteFile(target, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("new")),
+	}
+
+	if err := saveDownloadResponse(target, resp, 2); err == nil {
+		t.Fatal("expected short write limit to fail")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("expected existing file to be preserved, got %q", string(got))
 	}
 }

--- a/cli/cmd/ls.go
+++ b/cli/cmd/ls.go
@@ -7,6 +7,13 @@ import (
 )
 
 var lsLong bool
+var lsOffset int64
+var lsLimit int64
+
+const (
+	defaultLSLimit int64 = 100
+	maxLSLimit     int64 = 500
+)
 
 var lsCmd = &cobra.Command{
 	Use:   "ls [remote_path]",
@@ -23,7 +30,8 @@ var lsCmd = &cobra.Command{
 			return &exitError{code: output.ExitNotFound, msg: err.Error()}
 		}
 
-		files, err := client.List(dirID)
+		offset, limit := normalizeLSPage(lsOffset, lsLimit)
+		files, err := client.ListPage(dirID, offset, limit)
 		if err != nil {
 			return &exitError{code: output.ExitError, msg: err.Error()}
 		}
@@ -44,5 +52,20 @@ var lsCmd = &cobra.Command{
 
 func init() {
 	lsCmd.Flags().BoolVarP(&lsLong, "long", "l", false, "Show detailed listing")
+	lsCmd.Flags().Int64Var(&lsOffset, "offset", 0, "Offset for paginated listing")
+	lsCmd.Flags().Int64Var(&lsLimit, "limit", defaultLSLimit, "Max items to list")
 	rootCmd.AddCommand(lsCmd)
+}
+
+func normalizeLSPage(offset, limit int64) (int64, int64) {
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		limit = defaultLSLimit
+	}
+	if limit > maxLSLimit {
+		limit = maxLSLimit
+	}
+	return offset, limit
 }

--- a/cli/cmd/ls.go
+++ b/cli/cmd/ls.go
@@ -41,6 +41,10 @@ var lsCmd = &cobra.Command{
 			jsonFiles = append(jsonFiles, output.FileToJSON(&f))
 		}
 
+		if jsonOutput {
+			printer.PrintSuccess(buildLSJSONResponse(remotePath, jsonFiles, offset, limit))
+			return nil
+		}
 		if lsLong {
 			printer.PrintFileTable(remotePath, jsonFiles)
 		} else {
@@ -68,4 +72,16 @@ func normalizeLSPage(offset, limit int64) (int64, int64) {
 		limit = maxLSLimit
 	}
 	return offset, limit
+}
+
+func buildLSJSONResponse(path string, files []output.JSONFile, offset, limit int64) map[string]interface{} {
+	hasMore := limit > 0 && int64(len(files)) == limit
+	return map[string]interface{}{
+		"path":        path,
+		"files":       files,
+		"offset":      offset,
+		"limit":       limit,
+		"has_more":    hasMore,
+		"next_offset": offset + int64(len(files)),
+	}
 }

--- a/cli/cmd/ls.go
+++ b/cli/cmd/ls.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/SheltonZhu/115driver/cli/internal/output"
 	"github.com/SheltonZhu/115driver/cli/internal/resolver"
 	"github.com/spf13/cobra"
@@ -50,6 +53,9 @@ var lsCmd = &cobra.Command{
 		} else {
 			printer.PrintFileList(remotePath, jsonFiles)
 		}
+		if notice := buildLSTextPaginationNotice(len(jsonFiles), offset, limit); notice != "" {
+			fmt.Fprint(os.Stderr, notice)
+		}
 		return nil
 	},
 }
@@ -84,4 +90,12 @@ func buildLSJSONResponse(path string, files []output.JSONFile, offset, limit int
 		"has_more":    hasMore,
 		"next_offset": offset + int64(len(files)),
 	}
+}
+
+func buildLSTextPaginationNotice(fileCount int, offset, limit int64) string {
+	if limit <= 0 || int64(fileCount) < limit {
+		return ""
+	}
+	nextOffset := offset + int64(fileCount)
+	return fmt.Sprintf("Showing %d entries. Use --offset %d to continue.\n", fileCount, nextOffset)
 }

--- a/cli/cmd/ls_test.go
+++ b/cli/cmd/ls_test.go
@@ -18,3 +18,16 @@ func TestNormalizeLSPageCapsLargeLimit(t *testing.T) {
 		t.Fatalf("expected max limit %d, got %d", maxLSLimit, limit)
 	}
 }
+
+func TestBuildLSJSONResponseIncludesPaginationMetadata(t *testing.T) {
+	resp := buildLSJSONResponse("/", nil, 10, 5)
+	if resp["offset"] != int64(10) {
+		t.Fatalf("unexpected offset: %v", resp["offset"])
+	}
+	if resp["limit"] != int64(5) {
+		t.Fatalf("unexpected limit: %v", resp["limit"])
+	}
+	if resp["has_more"] != false {
+		t.Fatalf("unexpected has_more: %v", resp["has_more"])
+	}
+}

--- a/cli/cmd/ls_test.go
+++ b/cli/cmd/ls_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "testing"
+
+func TestNormalizeLSPageDefaultsToBoundedLimit(t *testing.T) {
+	offset, limit := normalizeLSPage(0, 0)
+	if offset != 0 {
+		t.Fatalf("unexpected offset: %d", offset)
+	}
+	if limit != defaultLSLimit {
+		t.Fatalf("expected default limit %d, got %d", defaultLSLimit, limit)
+	}
+}
+
+func TestNormalizeLSPageCapsLargeLimit(t *testing.T) {
+	_, limit := normalizeLSPage(0, maxLSLimit+1)
+	if limit != maxLSLimit {
+		t.Fatalf("expected max limit %d, got %d", maxLSLimit, limit)
+	}
+}

--- a/cli/cmd/ls_test.go
+++ b/cli/cmd/ls_test.go
@@ -31,3 +31,17 @@ func TestBuildLSJSONResponseIncludesPaginationMetadata(t *testing.T) {
 		t.Fatalf("unexpected has_more: %v", resp["has_more"])
 	}
 }
+
+func TestBuildLSTextPaginationNoticeShowsNextOffsetWhenPageIsFull(t *testing.T) {
+	got := buildLSTextPaginationNotice(100, 200, 100)
+	want := "Showing 100 entries. Use --offset 300 to continue.\n"
+	if got != want {
+		t.Fatalf("unexpected notice: got %q want %q", got, want)
+	}
+}
+
+func TestBuildLSTextPaginationNoticeEmptyWhenPageIsNotFull(t *testing.T) {
+	if got := buildLSTextPaginationNotice(99, 0, 100); got != "" {
+		t.Fatalf("expected no notice, got %q", got)
+	}
+}

--- a/cli/cmd/rm.go
+++ b/cli/cmd/rm.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -25,7 +26,11 @@ var rmCmd = &cobra.Command{
 			return &exitError{code: output.ExitNotFound, msg: err.Error()}
 		}
 
-		if isDir && !jsonOutput {
+		if err := validateDeleteConfirmation(isDir, jsonOutput, rmForce); err != nil {
+			return &exitError{code: output.ExitArgs, msg: err.Error()}
+		}
+
+		if isDir && !jsonOutput && !rmForce {
 			fmt.Printf("Delete directory %s and all its contents? [y/N] ", remotePath)
 			reader := bufio.NewReader(os.Stdin)
 			resp, _ := reader.ReadString('\n')
@@ -52,6 +57,19 @@ var rmCmd = &cobra.Command{
 }
 
 func init() {
-	rmCmd.Flags().BoolVarP(&rmForce, "force", "f", false, "Reserved for future permanent delete")
+	rmCmd.Flags().BoolVarP(&rmForce, "force", "f", false, "Skip confirmation for directory deletes")
 	rootCmd.AddCommand(rmCmd)
+}
+
+func validateDeleteConfirmation(isDir, jsonOutput, force bool) error {
+	if !isDir {
+		return nil
+	}
+	if force {
+		return nil
+	}
+	if jsonOutput {
+		return errors.New("directory delete requires --force when using --json")
+	}
+	return nil
 }

--- a/cli/cmd/rm_test.go
+++ b/cli/cmd/rm_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import "testing"
+
+func TestRmDirectoryRequiresForceForJSONOutput(t *testing.T) {
+	if err := validateDeleteConfirmation(true, true, false); err == nil {
+		t.Fatal("expected json directory delete without force to be rejected")
+	}
+}
+
+func TestRmDirectoryForceSkipsConfirmation(t *testing.T) {
+	if err := validateDeleteConfirmation(true, true, true); err != nil {
+		t.Fatalf("expected force delete to be allowed: %v", err)
+	}
+}
+
+func TestRmFileDoesNotRequireForce(t *testing.T) {
+	if err := validateDeleteConfirmation(false, true, false); err != nil {
+		t.Fatalf("expected file delete to be allowed: %v", err)
+	}
+}

--- a/cli/internal/resolver/resolver.go
+++ b/cli/internal/resolver/resolver.go
@@ -17,7 +17,10 @@ const RootID = "0"
 type pathResolverClient interface {
 	DirName2CID(dir string) (*driver.APIGetDirIDResp, error)
 	List(dirID string, opts ...driver.ListOption) (*[]driver.File, error)
+	ListPage(dirID string, offset, limit int64, opts ...driver.ListOption) (*[]driver.File, error)
 }
+
+const fileResolvePageLimit int64 = 100
 
 func ResolveDir(client pathResolverClient, remotePath string) (string, error) {
 	if remotePath == "" || remotePath == "/" {
@@ -59,14 +62,21 @@ func ResolveFile(client pathResolverClient, remotePath string) (string, error) {
 		}
 	}
 
-	files, err := client.List(dirID)
-	if err != nil {
-		return "", fmt.Errorf("failed to list directory: %w", err)
-	}
-
-	for _, f := range *files {
-		if f.Name == fileName && !f.IsDirectory {
-			return f.FileID, nil
+	for offset := int64(0); ; offset += fileResolvePageLimit {
+		files, err := client.ListPage(dirID, offset, fileResolvePageLimit)
+		if err != nil {
+			return "", fmt.Errorf("failed to list directory: %w", err)
+		}
+		if len(*files) == 0 {
+			break
+		}
+		for _, f := range *files {
+			if f.Name == fileName && !f.IsDirectory {
+				return f.FileID, nil
+			}
+		}
+		if int64(len(*files)) < fileResolvePageLimit {
+			break
 		}
 	}
 	return "", fmt.Errorf("file not found: %s", remotePath)
@@ -102,10 +112,6 @@ func ResolveLocalDownloadPath(localTarget, fileName string) string {
 
 	if strings.HasSuffix(localTarget, string(filepath.Separator)) {
 		return filepath.Join(strings.TrimSuffix(localTarget, string(filepath.Separator)), fileName)
-	}
-
-	if filepath.Ext(filepath.Base(localTarget)) == "" {
-		return filepath.Join(localTarget, fileName)
 	}
 
 	return localTarget

--- a/cli/internal/resolver/resolver_test.go
+++ b/cli/internal/resolver/resolver_test.go
@@ -11,18 +11,20 @@ func TestResolvePath_FallsBackToFileWhenDirLookupReturnsRootID(t *testing.T) {
 		dirIDs: map[string]string{
 			"q9tVD1jYR8e626EteJ0qDQ.mp4": RootID,
 		},
-		filesByDir: map[string][]driver.File{
+		pagesByDir: map[string][][]driver.File{
 			RootID: {
 				{
-					FileID:      "123456",
-					Name:        "q9tVD1jYR8e626EteJ0qDQ.mp4",
-					IsDirectory: false,
+					{
+						FileID:      "123456",
+						Name:        "q9tVD1jYR8e626EteJ0qDQ.mp4",
+						IsDirectory: false,
+					},
 				},
 			},
 		},
 	}
 
-	fileID, isDir, err := ResolvePath(client, "q9tVD1jYR8e626EteJ0qDQ.mp4")
+	fileID, isDir, err := ResolvePath(&client, "q9tVD1jYR8e626EteJ0qDQ.mp4")
 	if err != nil {
 		t.Fatalf("ResolvePath returned error: %v", err)
 	}
@@ -35,7 +37,7 @@ func TestResolvePath_FallsBackToFileWhenDirLookupReturnsRootID(t *testing.T) {
 }
 
 func TestResolvePath_RootStillResolvesToDirectory(t *testing.T) {
-	fileID, isDir, err := ResolvePath(fakeResolverClient{}, "/")
+	fileID, isDir, err := ResolvePath(&fakeResolverClient{}, "/")
 	if err != nil {
 		t.Fatalf("ResolvePath returned error: %v", err)
 	}
@@ -47,9 +49,38 @@ func TestResolvePath_RootStillResolvesToDirectory(t *testing.T) {
 	}
 }
 
+func TestResolveFileSearchesDirectoryByPages(t *testing.T) {
+	client := fakeResolverClient{
+		dirIDs: map[string]string{"movies": "dir1"},
+		pagesByDir: map[string][][]driver.File{
+			"dir1": {
+				repeatFiles(fileResolvePageLimit, "filler"),
+				{{FileID: "2", Name: "target.mp4"}},
+			},
+		},
+	}
+
+	fileID, err := ResolveFile(&client, "/movies/target.mp4")
+	if err != nil {
+		t.Fatalf("ResolveFile returned error: %v", err)
+	}
+	if fileID != "2" {
+		t.Fatalf("unexpected file ID: %s", fileID)
+	}
+	if client.listAllCalls != 0 {
+		t.Fatalf("expected ResolveFile not to call full List, got %d calls", client.listAllCalls)
+	}
+	if client.listPageCalls != 2 {
+		t.Fatalf("expected ResolveFile to scan 2 pages, got %d", client.listPageCalls)
+	}
+}
+
 type fakeResolverClient struct {
-	dirIDs     map[string]string
-	filesByDir map[string][]driver.File
+	dirIDs        map[string]string
+	filesByDir    map[string][]driver.File
+	pagesByDir    map[string][][]driver.File
+	listAllCalls  int
+	listPageCalls int
 }
 
 func (f fakeResolverClient) DirName2CID(dir string) (*driver.APIGetDirIDResp, error) {
@@ -59,7 +90,28 @@ func (f fakeResolverClient) DirName2CID(dir string) (*driver.APIGetDirIDResp, er
 	}, nil
 }
 
-func (f fakeResolverClient) List(dirID string, _ ...driver.ListOption) (*[]driver.File, error) {
+func (f *fakeResolverClient) List(dirID string, _ ...driver.ListOption) (*[]driver.File, error) {
+	f.listAllCalls++
 	files := f.filesByDir[dirID]
 	return &files, nil
+}
+
+func (f *fakeResolverClient) ListPage(dirID string, offset, limit int64, _ ...driver.ListOption) (*[]driver.File, error) {
+	f.listPageCalls++
+	page := int(offset / limit)
+	pages := f.pagesByDir[dirID]
+	if page >= len(pages) {
+		files := []driver.File{}
+		return &files, nil
+	}
+	files := pages[page]
+	return &files, nil
+}
+
+func repeatFiles(count int64, prefix string) []driver.File {
+	files := make([]driver.File, 0, count)
+	for i := int64(0); i < count; i++ {
+		files = append(files, driver.File{FileID: prefix, Name: prefix})
+	}
+	return files
 }

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -10,14 +10,36 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/SheltonZhu/115driver/mcp/server"
 	"github.com/SheltonZhu/115driver/pkg/driver"
 )
 
 var (
-	cookie = flag.String("cookie", "", "115 driver cookie for authentication")
-	help   = flag.Bool("help", false, "display help information")
+	cookie            = flag.String("cookie", "", "115 driver cookie for authentication")
+	localRoot         = flag.String("local-root", "", "allow MCP local file tools to read/write only under this directory")
+	urlUploadMaxBytes = flag.Int64(
+		"url-upload-max-bytes",
+		2<<30,
+		"maximum bytes for upload_from_url downloads, use 0 to disable",
+	)
+	downloadMaxBytes = flag.Int64(
+		"download-max-bytes",
+		0,
+		"maximum bytes for download_file downloads, use 0 to disable",
+	)
+	allowDestructive = flag.Bool(
+		"allow-destructive-tools",
+		false,
+		"register MCP tools that mutate 115 cloud state",
+	)
+	downloadTimeout = flag.Duration(
+		"download-timeout",
+		2*time.Hour,
+		"timeout for MCP HTTP downloads and URL uploads, use 0 to disable",
+	)
+	help = flag.Bool("help", false, "display help information")
 )
 
 func main() {
@@ -39,8 +61,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	cr := &driver.Credential{}
-	cr.FromCookie(*cookie)
+	cr, err := credentialFromCookie(*cookie)
+	if err != nil {
+		log.Fatalf("Invalid cookie: %v", err)
+	}
 	// Create 115 driver client and authenticate
 	client := driver.New(driver.UA(driver.UA115Browser)).ImportCredential(cr)
 
@@ -50,8 +74,21 @@ func main() {
 	}
 
 	// Create and start the MCP server
-	s := server.NewServer().WithClient(client)
+	s := server.NewServer().
+		WithClient(client).
+		WithLocalRoot(*localRoot).
+		WithDownloadTimeout(*downloadTimeout).
+		WithTransferSizeLimits(*urlUploadMaxBytes, *downloadMaxBytes).
+		WithDestructiveTools(*allowDestructive)
 	if err := s.Start(context.Background()); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
+}
+
+func credentialFromCookie(cookie string) (*driver.Credential, error) {
+	cr := &driver.Credential{}
+	if err := cr.FromCookie(cookie); err != nil {
+		return nil, err
+	}
+	return cr, nil
 }

--- a/mcp/main.go
+++ b/mcp/main.go
@@ -60,6 +60,9 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Usage: %s --cookie=\"UID=xxx;CID=xxx;SEID=xxx\"\n", os.Args[0])
 		os.Exit(1)
 	}
+	if err := validateOptions(*urlUploadMaxBytes, *downloadMaxBytes, *downloadTimeout); err != nil {
+		log.Fatalf("Invalid options: %v", err)
+	}
 
 	cr, err := credentialFromCookie(*cookie)
 	if err != nil {
@@ -91,4 +94,17 @@ func credentialFromCookie(cookie string) (*driver.Credential, error) {
 		return nil, err
 	}
 	return cr, nil
+}
+
+func validateOptions(urlUploadMaxBytes, downloadMaxBytes int64, downloadTimeout time.Duration) error {
+	if urlUploadMaxBytes < 0 {
+		return fmt.Errorf("url-upload-max-bytes must be >= 0")
+	}
+	if downloadMaxBytes < 0 {
+		return fmt.Errorf("download-max-bytes must be >= 0")
+	}
+	if downloadTimeout < 0 {
+		return fmt.Errorf("download-timeout must be >= 0")
+	}
+	return nil
 }

--- a/mcp/main_test.go
+++ b/mcp/main_test.go
@@ -1,9 +1,33 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestCredentialFromCookieRejectsInvalidCookie(t *testing.T) {
 	if _, err := credentialFromCookie("bad-cookie"); err == nil {
 		t.Fatal("expected invalid cookie to be rejected")
+	}
+}
+
+func TestValidateOptionsRejectsNegativeTransferLimits(t *testing.T) {
+	if err := validateOptions(-1, 0, time.Hour); err == nil {
+		t.Fatal("expected negative URL upload limit to be rejected")
+	}
+	if err := validateOptions(0, -1, time.Hour); err == nil {
+		t.Fatal("expected negative download limit to be rejected")
+	}
+}
+
+func TestValidateOptionsRejectsNegativeTimeout(t *testing.T) {
+	if err := validateOptions(0, 0, -time.Second); err == nil {
+		t.Fatal("expected negative timeout to be rejected")
+	}
+}
+
+func TestValidateOptionsAllowsZeroToDisableLimits(t *testing.T) {
+	if err := validateOptions(0, 0, 0); err != nil {
+		t.Fatalf("expected zero values to be accepted: %v", err)
 	}
 }

--- a/mcp/main_test.go
+++ b/mcp/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestCredentialFromCookieRejectsInvalidCookie(t *testing.T) {
+	if _, err := credentialFromCookie("bad-cookie"); err == nil {
+		t.Fatal("expected invalid cookie to be rejected")
+	}
+}

--- a/mcp/mcp_example.md
+++ b/mcp/mcp_example.md
@@ -18,6 +18,36 @@ Then run the server with your 115 cookies:
 
 The server will listen on stdin/stdout for MCP requests.
 
+Local file access is disabled by default. To allow `download_file` to write
+locally, and to allow `upload_from_local` to read local files when destructive
+tools are enabled, start the server with a local root; those tools can only read
+or write paths under that directory:
+
+```bash
+./mcp-server --cookie="UID=your_uid;CID=your_cid;SEID=your_seid" --local-root="/safe/path"
+```
+
+MCP HTTP transfers default to a 2 hour total timeout. Override it with
+`--download-timeout`, or use `--download-timeout=0` to disable the total timeout:
+
+```bash
+./mcp-server --cookie="UID=your_uid;CID=your_cid;SEID=your_seid" --download-timeout=6h
+```
+
+`download_file` has no size limit by default. `upload_from_url` defaults to a
+2 GiB limit because it buffers through a local temp file. Use
+`--download-max-bytes` or `--url-upload-max-bytes` to set limits; `0` disables
+the corresponding size limit.
+
+Tools that mutate 115 cloud state are not registered by default. Start the
+server with `--allow-destructive-tools` to enable directory creation, file
+rename/move/copy/delete, cloud uploads, recycle-bin mutations, and offline task
+mutations:
+
+```bash
+./mcp-server --cookie="UID=your_uid;CID=your_cid;SEID=your_seid" --allow-destructive-tools
+```
+
 ## Available Tools
 
 ### Account Tools
@@ -32,30 +62,30 @@ The server will listen on stdin/stdout for MCP requests.
    - Parameters:
      - `dir_id` (string): Directory ID to list, default is root directory (0)
      - `offset` (int64): Offset for pagination, default is 0
-     - `limit` (int64): Number of items to return, default is all items
+     - `limit` (int64): Number of items to return, default is 100, maximum is 500
 
-2. `mkdir`: Create a new directory
+2. `mkdir`: Create a new directory. Requires `--allow-destructive-tools`.
    - Parameters:
      - `parent_id` (string): Parent directory ID
      - `name` (string): Name of the new directory
 
 ### File Tools
 
-1. `delete`: Delete files or directories
+1. `delete`: Delete files or directories. Requires `--allow-destructive-tools`.
    - Parameters:
      - `file_ids` (array of strings): IDs of files or directories to delete
 
-2. `rename`: Rename a file or directory
+2. `rename`: Rename a file or directory. Requires `--allow-destructive-tools`.
    - Parameters:
      - `file_id` (string): ID of file or directory to rename
      - `new_name` (string): New name for the file or directory
 
-3. `move`: Move files or directories to another directory
+3. `move`: Move files or directories to another directory. Requires `--allow-destructive-tools`.
    - Parameters:
      - `dir_id` (string): Target directory ID
      - `file_ids` (array of strings): IDs of files or directories to move
 
-4. `copy`: Copy files or directories to another directory
+4. `copy`: Copy files or directories to another directory. Requires `--allow-destructive-tools`.
    - Parameters:
      - `dir_id` (string): Target directory ID
      - `file_ids` (array of strings): IDs of files or directories to copy
@@ -64,18 +94,44 @@ The server will listen on stdin/stdout for MCP requests.
    - Parameters:
      - `file_id` (string): ID of file or directory to get info
 
+6. `download_file`: Download a file from 115 cloud storage to a local path.
+   Requires `--local-root`.
+   - Parameters:
+     - `pick_code` (string): Pick code of the file to download
+     - `local_path` (string): Local path under `--local-root`
+     - `user_agent` (string): Optional User-Agent
+
+7. `get_download_info`: Get a file download URL and metadata
+   - Parameters:
+     - `pick_code` (string): Pick code of the file
+     - `user_agent` (string): Optional User-Agent
+
+8. `upload_from_url`: Download a URL and upload it to 115 cloud storage.
+   Requires `--allow-destructive-tools`.
+   - Parameters:
+     - `url` (string): HTTP or HTTPS URL to download
+     - `dir_id` (string): Target 115 directory ID
+     - `file_name` (string): Optional destination file name
+
+9. `upload_from_local`: Upload a local file to 115 cloud storage.
+   Requires `--allow-destructive-tools` and `--local-root`.
+   - Parameters:
+     - `local_path` (string): Local file path under `--local-root`
+     - `dir_id` (string): Target 115 directory ID
+     - `file_name` (string): Optional destination file name
+
 ### Recycle Bin Tools
 
 1. `listRecycleBin`: List items in the recycle bin
    - Parameters:
-     - `offset` (string): Offset for pagination, default is 0
-     - `limit` (string): Number of items to return, default is 40
+     - `offset` (int): Offset for pagination, default is 0
+     - `limit` (int): Number of items to return, default is 40, maximum is 100
 
-2. `revertRecycleBin`: Revert items from the recycle bin
+2. `revertRecycleBin`: Revert items from the recycle bin. Requires `--allow-destructive-tools`.
    - Parameters:
      - `item_ids` (array of strings): IDs of items to revert
 
-3. `cleanRecycleBin`: Clean items from the recycle bin
+3. `cleanRecycleBin`: Clean items from the recycle bin. Requires `--allow-destructive-tools`.
    - Parameters:
      - `password` (string): Password for cleaning recycle bin
      - `item_ids` (array of strings): IDs of items to clean
@@ -105,17 +161,17 @@ The server will listen on stdin/stdout for MCP requests.
    - Parameters:
      - `page` (int64): Page number for pagination, default is 1
 
-2. `addOfflineTaskURIs`: Add offline tasks by download URIs, supports http, ed2k, magnet
+2. `addOfflineTaskURIs`: Add offline tasks by download URIs, supports http, ed2k, magnet. Requires `--allow-destructive-tools`.
    - Parameters:
      - `uris` (array of strings): Download URIs, supports http, ed2k, magnet
      - `save_dir_id` (string): Directory ID to save downloaded files
 
-3. `deleteOfflineTasks`: Delete offline tasks
+3. `deleteOfflineTasks`: Delete offline tasks. Requires `--allow-destructive-tools`.
    - Parameters:
      - `hashes` (array of strings): Task hashes to delete
      - `delete_files` (bool): Whether to delete associated files, default is false
 
-4. `clearOfflineTasks`: Clear offline tasks
+4. `clearOfflineTasks`: Clear offline tasks. Requires `--allow-destructive-tools`.
    - Parameters:
      - `clear_flag` (int64): Clear flag, 0: clear completed tasks, 1: clear all tasks
 

--- a/mcp/mcp_example.md
+++ b/mcp/mcp_example.md
@@ -38,6 +38,8 @@ MCP HTTP transfers default to a 2 hour total timeout. Override it with
 2 GiB limit because it buffers through a local temp file. Use
 `--download-max-bytes` or `--url-upload-max-bytes` to set limits; `0` disables
 the corresponding size limit.
+For SSRF protection, `upload_from_url` rejects non-HTTP(S) URLs, redirects to
+unsafe hosts, and hostnames that resolve to loopback/private/link-local IPs.
 
 Tools that mutate 115 cloud state are not registered by default. Start the
 server with `--allow-destructive-tools` to enable directory creation, file

--- a/mcp/mcp_example.md
+++ b/mcp/mcp_example.md
@@ -68,7 +68,7 @@ mutations:
    - Parameters:
      - `dir_id` (string): Directory ID to list, default is root directory (0)
      - `offset` (int64): Offset for pagination, default is 0
-     - `limit` (int64): Number of items to return, default is 100, maximum is 500
+     - `limit` (int64): Number of items to return. Omit or set to 0 to return all items; positive limits are capped at 500
 
 2. `mkdir`: Create a new directory. Requires `--allow-destructive-tools`.
    - Parameters:

--- a/mcp/mcp_example.md
+++ b/mcp/mcp_example.md
@@ -40,6 +40,8 @@ MCP HTTP transfers default to a 2 hour total timeout. Override it with
 the corresponding size limit.
 For SSRF protection, `upload_from_url` rejects non-HTTP(S) URLs, redirects to
 unsafe hosts, and hostnames that resolve to loopback/private/link-local IPs.
+When a hostname resolves to multiple safe IPs, MCP HTTP transfers try the later
+addresses if earlier addresses are unreachable.
 
 Tools that mutate 115 cloud state are not registered by default. Start the
 server with `--allow-destructive-tools` to enable directory creation, file

--- a/mcp/mcp_example.md
+++ b/mcp/mcp_example.md
@@ -21,7 +21,9 @@ The server will listen on stdin/stdout for MCP requests.
 Local file access is disabled by default. To allow `download_file` to write
 locally, and to allow `upload_from_local` to read local files when destructive
 tools are enabled, start the server with a local root; those tools can only read
-or write paths under that directory:
+or write paths under that directory. Existing target paths and existing parent
+directories are resolved before the boundary check, so symlinks cannot point
+local file tools outside `--local-root`:
 
 ```bash
 ./mcp-server --cookie="UID=your_uid;CID=your_cid;SEID=your_seid" --local-root="/safe/path"

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/SheltonZhu/115driver/mcp/server/tools"
 	"github.com/SheltonZhu/115driver/pkg/driver"
@@ -11,8 +12,13 @@ import (
 
 // Server represents the 115driver MCP server
 type Server struct {
-	mcpServer *mcp.Server
-	client    *driver.Pan115Client
+	mcpServer         *mcp.Server
+	client            *driver.Pan115Client
+	localRoot         string
+	downloadTimeout   time.Duration
+	urlUploadMaxBytes int64
+	downloadMaxBytes  int64
+	allowDestructive  bool
 }
 
 // NewServer creates a new 115driver MCP server
@@ -28,6 +34,31 @@ func NewServer() *Server {
 // WithClient sets the 115 driver client for the server
 func (s *Server) WithClient(client *driver.Pan115Client) *Server {
 	s.client = client
+	return s
+}
+
+// WithLocalRoot restricts local file tools to paths under root. Empty disables them.
+func (s *Server) WithLocalRoot(root string) *Server {
+	s.localRoot = root
+	return s
+}
+
+// WithDownloadTimeout sets the total timeout for MCP HTTP transfers. Zero disables it.
+func (s *Server) WithDownloadTimeout(timeout time.Duration) *Server {
+	s.downloadTimeout = timeout
+	return s
+}
+
+// WithTransferSizeLimits sets size limits for MCP HTTP transfers. Zero disables a limit.
+func (s *Server) WithTransferSizeLimits(urlUploadMaxBytes, downloadMaxBytes int64) *Server {
+	s.urlUploadMaxBytes = urlUploadMaxBytes
+	s.downloadMaxBytes = downloadMaxBytes
+	return s
+}
+
+// WithDestructiveTools controls MCP tools that mutate 115 cloud state.
+func (s *Server) WithDestructiveTools(allow bool) *Server {
+	s.allowDestructive = allow
 	return s
 }
 
@@ -55,11 +86,18 @@ func (s *Server) registerTools() {
 	dirTools.RegisterTools(s.mcpServer)
 
 	// Register file tools
-	fileTools := tools.NewFileTools(s.client)
+	fileTools := tools.NewFileTools(
+		s.client,
+		tools.WithLocalRoot(s.localRoot),
+		tools.WithDownloadTimeout(s.downloadTimeout),
+		tools.WithURLUploadMaxBytes(s.urlUploadMaxBytes),
+		tools.WithDownloadMaxBytes(s.downloadMaxBytes),
+		tools.WithDestructiveTools(s.allowDestructive),
+	)
 	fileTools.RegisterTools(s.mcpServer)
 
 	// Register recycle tools
-	recycleTools := tools.NewRecycleTools(s.client)
+	recycleTools := tools.NewRecycleTools(s.client, tools.WithRecycleDestructiveTools(s.allowDestructive))
 	recycleTools.RegisterTools(s.mcpServer)
 
 	// Register share tools
@@ -71,6 +109,6 @@ func (s *Server) registerTools() {
 	searchTools.RegisterTools(s.mcpServer)
 
 	// Register offline tools
-	offlineTools := tools.NewOfflineTools(s.client)
+	offlineTools := tools.NewOfflineTools(s.client, tools.WithOfflineDestructiveTools(s.allowDestructive))
 	offlineTools.RegisterTools(s.mcpServer)
 }

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -24,6 +24,9 @@ type Server struct {
 // NewServer creates a new 115driver MCP server
 func NewServer() *Server {
 	return &Server{
+		downloadTimeout:   2 * time.Hour,
+		urlUploadMaxBytes: 2 << 30,
+		downloadMaxBytes:  0,
 		mcpServer: mcp.NewServer(&mcp.Implementation{
 			Name:    "115driver-mcp-server",
 			Version: "1.0.0",

--- a/mcp/server/server_test.go
+++ b/mcp/server/server_test.go
@@ -1,0 +1,19 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewServerPreservesTransferDefaults(t *testing.T) {
+	s := NewServer()
+	if s.downloadTimeout != 2*time.Hour {
+		t.Fatalf("unexpected default download timeout: %s", s.downloadTimeout)
+	}
+	if s.urlUploadMaxBytes != 2<<30 {
+		t.Fatalf("unexpected default URL upload limit: %d", s.urlUploadMaxBytes)
+	}
+	if s.downloadMaxBytes != 0 {
+		t.Fatalf("expected default download limit to be disabled, got %d", s.downloadMaxBytes)
+	}
+}

--- a/mcp/server/tools/destructive_test.go
+++ b/mcp/server/tools/destructive_test.go
@@ -1,0 +1,17 @@
+package tools
+
+import "testing"
+
+func TestDestructiveToolsDisabledByDefault(t *testing.T) {
+	ft := NewFileTools(nil)
+	if ft.allowDestructive {
+		t.Fatal("expected destructive MCP tools to be disabled by default")
+	}
+}
+
+func TestWithDestructiveToolsAllowsDestructiveTools(t *testing.T) {
+	ft := NewFileTools(nil, WithDestructiveTools(true))
+	if !ft.allowDestructive {
+		t.Fatal("expected destructive MCP tools to be enabled")
+	}
+}

--- a/mcp/server/tools/dir.go
+++ b/mcp/server/tools/dir.go
@@ -14,6 +14,11 @@ type DirTools struct {
 	client *driver.Pan115Client
 }
 
+const (
+	defaultDirectoryListLimit int64 = 100
+	maxDirectoryListLimit     int64 = 500
+)
+
 // NewDirTools creates a new DirTools instance
 func NewDirTools(client *driver.Pan115Client) *DirTools {
 	return &DirTools{
@@ -42,13 +47,8 @@ func (dt *DirTools) listDirectory(ctx context.Context, req *mcp.CallToolRequest,
 		err   error
 	)
 
-	// If offset and limit are specified, use pagination
-	if args.Limit > 0 {
-		files, err = dt.client.ListPage(args.DirID, args.Offset, args.Limit)
-	} else {
-		// Otherwise, list all files (existing behavior)
-		files, err = dt.client.List(args.DirID)
-	}
+	offset, limit := normalizeDirectoryListPagination(args.Offset, args.Limit)
+	files, err = dt.client.ListPage(args.DirID, offset, limit)
 
 	if err != nil {
 		return &mcp.CallToolResult{
@@ -81,4 +81,17 @@ func (dt *DirTools) listDirectory(ctx context.Context, req *mcp.CallToolRequest,
 			},
 		},
 	}, nil, nil
+}
+
+func normalizeDirectoryListPagination(offset, limit int64) (int64, int64) {
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		limit = defaultDirectoryListLimit
+	}
+	if limit > maxDirectoryListLimit {
+		limit = maxDirectoryListLimit
+	}
+	return offset, limit
 }

--- a/mcp/server/tools/dir.go
+++ b/mcp/server/tools/dir.go
@@ -15,8 +15,7 @@ type DirTools struct {
 }
 
 const (
-	defaultDirectoryListLimit int64 = 100
-	maxDirectoryListLimit     int64 = 500
+	maxDirectoryListLimit int64 = 500
 )
 
 // NewDirTools creates a new DirTools instance
@@ -48,7 +47,11 @@ func (dt *DirTools) listDirectory(ctx context.Context, req *mcp.CallToolRequest,
 	)
 
 	offset, limit := normalizeDirectoryListPagination(args.Offset, args.Limit)
-	files, err = dt.client.ListPage(args.DirID, offset, limit)
+	if limit > 0 {
+		files, err = dt.client.ListPage(args.DirID, offset, limit)
+	} else {
+		files, err = dt.client.List(args.DirID)
+	}
 
 	if err != nil {
 		return &mcp.CallToolResult{
@@ -88,7 +91,7 @@ func normalizeDirectoryListPagination(offset, limit int64) (int64, int64) {
 		offset = 0
 	}
 	if limit <= 0 {
-		limit = defaultDirectoryListLimit
+		return 0, 0
 	}
 	if limit > maxDirectoryListLimit {
 		limit = maxDirectoryListLimit

--- a/mcp/server/tools/dir_test.go
+++ b/mcp/server/tools/dir_test.go
@@ -1,0 +1,20 @@
+package tools
+
+import "testing"
+
+func TestNormalizeDirectoryListLimitDefaultsToBoundedPage(t *testing.T) {
+	offset, limit := normalizeDirectoryListPagination(0, 0)
+	if offset != 0 {
+		t.Fatalf("unexpected offset: %d", offset)
+	}
+	if limit != defaultDirectoryListLimit {
+		t.Fatalf("expected default limit %d, got %d", defaultDirectoryListLimit, limit)
+	}
+}
+
+func TestNormalizeDirectoryListLimitCapsLargeLimit(t *testing.T) {
+	_, limit := normalizeDirectoryListPagination(0, maxDirectoryListLimit+1)
+	if limit != maxDirectoryListLimit {
+		t.Fatalf("expected max limit %d, got %d", maxDirectoryListLimit, limit)
+	}
+}

--- a/mcp/server/tools/dir_test.go
+++ b/mcp/server/tools/dir_test.go
@@ -2,13 +2,13 @@ package tools
 
 import "testing"
 
-func TestNormalizeDirectoryListLimitDefaultsToBoundedPage(t *testing.T) {
-	offset, limit := normalizeDirectoryListPagination(0, 0)
+func TestNormalizeDirectoryListLimitPreservesUnpaginatedDefault(t *testing.T) {
+	offset, limit := normalizeDirectoryListPagination(25, 0)
 	if offset != 0 {
 		t.Fatalf("unexpected offset: %d", offset)
 	}
-	if limit != defaultDirectoryListLimit {
-		t.Fatalf("expected default limit %d, got %d", defaultDirectoryListLimit, limit)
+	if limit != 0 {
+		t.Fatalf("expected zero limit to request full listing, got %d", limit)
 	}
 }
 

--- a/mcp/server/tools/file.go
+++ b/mcp/server/tools/file.go
@@ -842,7 +842,10 @@ func validateLocalPath(root, target string, mustExist bool) (string, error) {
 
 	pathToCheck := absTarget
 	if !mustExist && !pathExists(absTarget) {
-		pathToCheck = filepath.Dir(absTarget)
+		pathToCheck, err = nearestExistingPath(filepath.Dir(absTarget))
+		if err != nil {
+			return "", err
+		}
 	}
 	realCheck, err := filepath.EvalSymlinks(pathToCheck)
 	if err != nil {
@@ -860,6 +863,19 @@ func validateLocalPath(root, target string, mustExist bool) (string, error) {
 		return "", errors.New("path escapes local root")
 	}
 	return absTarget, nil
+}
+
+func nearestExistingPath(path string) (string, error) {
+	for {
+		if pathExists(path) {
+			return path, nil
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", fmt.Errorf("no existing parent for %q", path)
+		}
+		path = parent
+	}
 }
 
 func pathExists(path string) bool {

--- a/mcp/server/tools/file.go
+++ b/mcp/server/tools/file.go
@@ -3,10 +3,15 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
-	"strings"
+	"path/filepath"
+	"time"
 
 	"github.com/SheltonZhu/115driver/pkg/driver"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -14,15 +19,70 @@ import (
 
 // FileTools holds file-related MCP tools
 type FileTools struct {
-	client *driver.Pan115Client
+	client            *driver.Pan115Client
+	localRoot         string
+	downloadTimeout   time.Duration
+	urlUploadMaxBytes int64
+	downloadMaxBytes  int64
+	allowDestructive  bool
+}
+
+type FileToolsOption func(*FileTools)
+
+func WithLocalRoot(root string) FileToolsOption {
+	return func(ft *FileTools) {
+		ft.localRoot = root
+	}
+}
+
+func WithDownloadTimeout(timeout time.Duration) FileToolsOption {
+	return func(ft *FileTools) {
+		ft.downloadTimeout = timeout
+	}
+}
+
+func WithURLUploadMaxBytes(maxBytes int64) FileToolsOption {
+	return func(ft *FileTools) {
+		ft.urlUploadMaxBytes = maxBytes
+	}
+}
+
+func WithDownloadMaxBytes(maxBytes int64) FileToolsOption {
+	return func(ft *FileTools) {
+		ft.downloadMaxBytes = maxBytes
+	}
+}
+
+func WithDestructiveTools(allow bool) FileToolsOption {
+	return func(ft *FileTools) {
+		ft.allowDestructive = allow
+	}
 }
 
 // NewFileTools creates a new FileTools instance
-func NewFileTools(client *driver.Pan115Client) *FileTools {
-	return &FileTools{
-		client: client,
+func NewFileTools(client *driver.Pan115Client, opts ...FileToolsOption) *FileTools {
+	ft := &FileTools{
+		client:            client,
+		downloadTimeout:   defaultMCPDownloadTimeout,
+		urlUploadMaxBytes: defaultMCPURLUploadMaxBytes,
+		downloadMaxBytes:  defaultMCPDownloadMaxBytes,
 	}
+	for _, opt := range opts {
+		opt(ft)
+	}
+	return ft
 }
+
+const (
+	defaultMCPURLUploadMaxBytes int64 = 2 << 30 // 2 GiB
+	defaultMCPDownloadMaxBytes  int64 = 0       // unlimited
+	defaultMCPDownloadTimeout         = 2 * time.Hour
+)
+
+var (
+	errUnexpectedHTTPStatus = errors.New("unexpected HTTP status")
+	errResponseTooLarge     = errors.New("response too large")
+)
 
 // MkdirArgs defines arguments for mkdir tool
 type MkdirArgs struct {
@@ -99,45 +159,49 @@ type DownloadFileResult struct {
 
 // RegisterTools registers file-related tools with the MCP server
 func (ft *FileTools) RegisterTools(server *mcp.Server) {
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "mkdir",
-		Description: "Create a new directory",
-	}, ft.mkdir)
+	if ft.allowDestructive {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "mkdir",
+			Description: "Create a new directory",
+		}, ft.mkdir)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "delete",
-		Description: "Delete files or directories",
-	}, ft.delete)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "delete",
+			Description: "Delete files or directories",
+		}, ft.delete)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "rename",
-		Description: "Rename a file or directory",
-	}, ft.rename)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "rename",
+			Description: "Rename a file or directory",
+		}, ft.rename)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "move",
-		Description: "Move files or directories to another directory",
-	}, ft.move)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "move",
+			Description: "Move files or directories to another directory",
+		}, ft.move)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "copy",
-		Description: "Copy files or directories to another directory",
-	}, ft.copy)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "copy",
+			Description: "Copy files or directories to another directory",
+		}, ft.copy)
+	}
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "stat",
 		Description: "Get detailed information about a file or directory",
 	}, ft.stat)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "upload_from_url",
-		Description: "Upload a file to 115 cloud storage from a URL",
-	}, ft.uploadFromURL)
+	if ft.allowDestructive {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "upload_from_url",
+			Description: "Upload a file to 115 cloud storage from a URL",
+		}, ft.uploadFromURL)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "upload_from_local",
-		Description: "Upload a local file to 115 cloud storage",
-	}, ft.uploadFromLocal)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "upload_from_local",
+			Description: "Upload a local file to 115 cloud storage",
+		}, ft.uploadFromLocal)
+	}
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "download_file",
@@ -187,7 +251,6 @@ func (ft *FileTools) mkdir(ctx context.Context, req *mcp.CallToolRequest, args M
 		},
 	}, nil, nil
 }
-
 
 func (ft *FileTools) delete(ctx context.Context, req *mcp.CallToolRequest, args DeleteArgs) (*mcp.CallToolResult, any, error) {
 	if len(args.FileIDs) == 0 {
@@ -357,8 +420,17 @@ func (ft *FileTools) stat(ctx context.Context, req *mcp.CallToolRequest, args St
 }
 
 func (ft *FileTools) uploadFromURL(ctx context.Context, req *mcp.CallToolRequest, args UploadFromURLArgs) (*mcp.CallToolResult, any, error) {
+	downloadURL, err := validateUploadURL(args.URL)
+	if err != nil {
+		return toolError(fmt.Sprintf("Invalid URL: %v", err)), nil, nil
+	}
+
 	// Download the file from the URL
-	resp, err := ft.client.Client.R().SetDoNotParseResponse(true).Get(args.URL)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL.String(), nil)
+	if err != nil {
+		return toolError(fmt.Sprintf("Failed to create download request: %v", err)), nil, nil
+	}
+	resp, err := newMCPHTTPClient(ft.downloadTimeout).Do(httpReq)
 	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -369,25 +441,13 @@ func (ft *FileTools) uploadFromURL(ctx context.Context, req *mcp.CallToolRequest
 			IsError: true,
 		}, nil, nil
 	}
-	defer resp.RawBody().Close()
-
-	if resp.StatusCode() != 200 {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{
-					Text: fmt.Sprintf("Failed to download file from URL, status code: %d", resp.StatusCode()),
-				},
-			},
-			IsError: true,
-		}, nil, nil
-	}
+	defer resp.Body.Close()
 
 	// If fileName is empty, try to extract it from the URL
 	fileName := args.FileName
 	if fileName == "" {
-		parts := strings.Split(args.URL, "/")
-		fileName = parts[len(parts)-1]
-		if fileName == "" {
+		fileName = filepath.Base(downloadURL.Path)
+		if fileName == "" || fileName == "." || fileName == "/" {
 			fileName = "downloaded_file"
 		}
 	}
@@ -408,7 +468,7 @@ func (ft *FileTools) uploadFromURL(ctx context.Context, req *mcp.CallToolRequest
 	defer tempFile.Close()
 
 	// Copy the response body to the temporary file
-	_, err = io.Copy(tempFile, resp.RawBody())
+	err = copyHTTPResponse(tempFile, resp, ft.urlUploadMaxBytes)
 	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -486,8 +546,13 @@ func (ft *FileTools) uploadFromURL(ctx context.Context, req *mcp.CallToolRequest
 }
 
 func (ft *FileTools) uploadFromLocal(ctx context.Context, req *mcp.CallToolRequest, args UploadFromLocalArgs) (*mcp.CallToolResult, any, error) {
+	localPath, err := validateLocalPath(ft.localRoot, args.LocalPath, true)
+	if err != nil {
+		return toolError(fmt.Sprintf("Local file access denied: %v", err)), nil, nil
+	}
+
 	// Open the local file
-	file, err := os.Open(args.LocalPath)
+	file, err := os.Open(localPath)
 	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -574,6 +639,11 @@ func (ft *FileTools) uploadFromLocal(ctx context.Context, req *mcp.CallToolReque
 }
 
 func (ft *FileTools) downloadFile(ctx context.Context, req *mcp.CallToolRequest, args DownloadFileArgs) (*mcp.CallToolResult, any, error) {
+	localPath, err := validateLocalPath(ft.localRoot, args.LocalPath, false)
+	if err != nil {
+		return toolError(fmt.Sprintf("Local file access denied: %v", err)), nil, nil
+	}
+
 	// Get download info with the specified User-Agent
 	downloadInfo, err := ft.client.DownloadWithUA(args.PickCode, args.UserAgent)
 	if err != nil {
@@ -588,12 +658,17 @@ func (ft *FileTools) downloadFile(ctx context.Context, req *mcp.CallToolRequest,
 	}
 
 	// Perform the actual download using the same User-Agent
-	reqDownload := ft.client.Client.R()
-	if args.UserAgent != "" {
-		reqDownload = reqDownload.SetHeader("User-Agent", args.UserAgent)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadInfo.Url.Url, nil)
+	if err != nil {
+		return toolError(fmt.Sprintf("Failed to create download request: %v", err)), nil, nil
+	}
+	for k, vals := range downloadInfo.Header {
+		for _, v := range vals {
+			httpReq.Header.Add(k, v)
+		}
 	}
 
-	resp, err := reqDownload.SetDoNotParseResponse(true).Get(downloadInfo.Url.Url)
+	resp, err := newMCPHTTPClient(ft.downloadTimeout).Do(httpReq)
 	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -604,10 +679,14 @@ func (ft *FileTools) downloadFile(ctx context.Context, req *mcp.CallToolRequest,
 			IsError: true,
 		}, nil, nil
 	}
-	defer resp.RawBody().Close()
+	defer resp.Body.Close()
+
+	if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+		return toolError(fmt.Sprintf("Failed to create local directory: %v", err)), nil, nil
+	}
 
 	// Create the local file
-	localFile, err := os.Create(args.LocalPath)
+	localFile, err := os.Create(localPath)
 	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -621,7 +700,7 @@ func (ft *FileTools) downloadFile(ctx context.Context, req *mcp.CallToolRequest,
 	defer localFile.Close()
 
 	// Copy the downloaded content to the local file
-	_, err = io.Copy(localFile, resp.RawBody())
+	err = copyHTTPResponse(localFile, resp, ft.downloadMaxBytes)
 	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
@@ -697,4 +776,111 @@ func (ft *FileTools) getDownloadInfo(ctx context.Context, req *mcp.CallToolReque
 			},
 		},
 	}, nil, nil
+}
+
+func validateUploadURL(rawURL string) (*url.URL, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %q", parsed.Scheme)
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return nil, errors.New("missing host")
+	}
+	if isUnsafeHost(host) {
+		return nil, fmt.Errorf("host %q is not allowed", host)
+	}
+	return parsed, nil
+}
+
+func isUnsafeHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return isUnsafeIP(ip)
+	}
+	return false
+}
+
+func isUnsafeIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified()
+}
+
+func validateLocalPath(root, target string, mustExist bool) (string, error) {
+	if root == "" {
+		return "", errors.New("local root is not configured")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	realRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve local root: %w", err)
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+
+	pathToCheck := absTarget
+	if !mustExist {
+		pathToCheck = filepath.Dir(absTarget)
+	}
+	realCheck, err := filepath.EvalSymlinks(pathToCheck)
+	if err != nil {
+		if mustExist || !os.IsNotExist(err) {
+			return "", err
+		}
+		realCheck = pathToCheck
+	}
+
+	rel, err := filepath.Rel(realRoot, realCheck)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator) {
+		return "", errors.New("path escapes local root")
+	}
+	return absTarget, nil
+}
+
+func copyHTTPResponse(dst io.Writer, resp *http.Response, maxBytes int64) error {
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: %d", errUnexpectedHTTPStatus, resp.StatusCode)
+	}
+	if maxBytes <= 0 {
+		_, err := io.Copy(dst, resp.Body)
+		return err
+	}
+	limited := &io.LimitedReader{R: resp.Body, N: maxBytes + 1}
+	written, err := io.Copy(dst, limited)
+	if err != nil {
+		return err
+	}
+	if written > maxBytes || limited.N == 0 {
+		return fmt.Errorf("%w: limit is %d bytes", errResponseTooLarge, maxBytes)
+	}
+	return nil
+}
+
+func newMCPHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout}
+}
+
+func toolError(text string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: text},
+		},
+		IsError: true,
+	}
 }

--- a/mcp/server/tools/file.go
+++ b/mcp/server/tools/file.go
@@ -82,6 +82,7 @@ const (
 var (
 	errUnexpectedHTTPStatus = errors.New("unexpected HTTP status")
 	errResponseTooLarge     = errors.New("response too large")
+	errInvalidSizeLimit     = errors.New("invalid size limit")
 )
 
 // MkdirArgs defines arguments for mkdir tool
@@ -887,7 +888,10 @@ func copyHTTPResponse(dst io.Writer, resp *http.Response, maxBytes int64) error 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%w: %d", errUnexpectedHTTPStatus, resp.StatusCode)
 	}
-	if maxBytes <= 0 {
+	if maxBytes < 0 {
+		return fmt.Errorf("%w: %d", errInvalidSizeLimit, maxBytes)
+	}
+	if maxBytes == 0 {
 		_, err := io.Copy(dst, resp.Body)
 		return err
 	}
@@ -930,6 +934,9 @@ func newMCPHTTPClient(timeout time.Duration) *http.Client {
 }
 
 func saveHTTPResponseToFile(path string, resp *http.Response, maxBytes int64) error {
+	if maxBytes < 0 {
+		return fmt.Errorf("%w: %d", errInvalidSizeLimit, maxBytes)
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}

--- a/mcp/server/tools/file.go
+++ b/mcp/server/tools/file.go
@@ -681,27 +681,7 @@ func (ft *FileTools) downloadFile(ctx context.Context, req *mcp.CallToolRequest,
 	}
 	defer resp.Body.Close()
 
-	if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
-		return toolError(fmt.Sprintf("Failed to create local directory: %v", err)), nil, nil
-	}
-
-	// Create the local file
-	localFile, err := os.Create(localPath)
-	if err != nil {
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{
-				&mcp.TextContent{
-					Text: fmt.Sprintf("Failed to create local file: %v", err),
-				},
-			},
-			IsError: true,
-		}, nil, nil
-	}
-	defer localFile.Close()
-
-	// Copy the downloaded content to the local file
-	err = copyHTTPResponse(localFile, resp, ft.downloadMaxBytes)
-	if err != nil {
+	if err := saveHTTPResponseToFile(localPath, resp, ft.downloadMaxBytes); err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{
@@ -806,6 +786,18 @@ func isUnsafeHost(host string) bool {
 	return false
 }
 
+func validateResolvedIPs(host string, ips []net.IP) error {
+	if len(ips) == 0 {
+		return fmt.Errorf("host %q did not resolve to any IPs", host)
+	}
+	for _, ip := range ips {
+		if ip == nil || isUnsafeIP(ip) {
+			return fmt.Errorf("host %q resolved to unsafe IP %s", host, ip)
+		}
+	}
+	return nil
+}
+
 func isUnsafeIP(ip net.IP) bool {
 	return ip.IsLoopback() ||
 		ip.IsPrivate() ||
@@ -832,7 +824,7 @@ func validateLocalPath(root, target string, mustExist bool) (string, error) {
 	}
 
 	pathToCheck := absTarget
-	if !mustExist {
+	if !mustExist && !pathExists(absTarget) {
 		pathToCheck = filepath.Dir(absTarget)
 	}
 	realCheck, err := filepath.EvalSymlinks(pathToCheck)
@@ -851,6 +843,11 @@ func validateLocalPath(root, target string, mustExist bool) (string, error) {
 		return "", errors.New("path escapes local root")
 	}
 	return absTarget, nil
+}
+
+func pathExists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil
 }
 
 func copyHTTPResponse(dst io.Writer, resp *http.Response, maxBytes int64) error {
@@ -873,7 +870,54 @@ func copyHTTPResponse(dst io.Writer, resp *http.Response, maxBytes int64) error 
 }
 
 func newMCPHTTPClient(timeout time.Duration) *http.Client {
-	return &http.Client{Timeout: timeout}
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	return &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if _, err := validateUploadURL(req.URL.String()); err != nil {
+				return err
+			}
+			return nil
+		},
+		Transport: &http.Transport{
+			Proxy: nil,
+			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+				host, port, err := net.SplitHostPort(address)
+				if err != nil {
+					return nil, err
+				}
+				ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+				if err != nil {
+					return nil, err
+				}
+				if err := validateResolvedIPs(host, ips); err != nil {
+					return nil, err
+				}
+				return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+			},
+		},
+	}
+}
+
+func saveHTTPResponseToFile(path string, resp *http.Response, maxBytes int64) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if err := copyHTTPResponse(tmp, resp, maxBytes); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func toolError(text string) *mcp.CallToolResult {

--- a/mcp/server/tools/file.go
+++ b/mcp/server/tools/file.go
@@ -798,6 +798,23 @@ func validateResolvedIPs(host string, ips []net.IP) error {
 	return nil
 }
 
+func dialResolvedIPs(ctx context.Context, network, host, port string, ips []net.IP, dial func(context.Context, string, string) (net.Conn, error)) (net.Conn, error) {
+	if err := validateResolvedIPs(host, ips); err != nil {
+		return nil, err
+	}
+
+	var errs []error
+	for _, ip := range ips {
+		address := net.JoinHostPort(ip.String(), port)
+		conn, err := dial(ctx, network, address)
+		if err == nil {
+			return conn, nil
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", address, err))
+	}
+	return nil, fmt.Errorf("dial %q: %w", host, errors.Join(errs...))
+}
+
 func isUnsafeIP(ip net.IP) bool {
 	return ip.IsLoopback() ||
 		ip.IsPrivate() ||
@@ -890,10 +907,7 @@ func newMCPHTTPClient(timeout time.Duration) *http.Client {
 				if err != nil {
 					return nil, err
 				}
-				if err := validateResolvedIPs(host, ips); err != nil {
-					return nil, err
-				}
-				return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+				return dialResolvedIPs(ctx, network, host, port, ips, dialer.DialContext)
 			},
 		},
 	}

--- a/mcp/server/tools/file_security_test.go
+++ b/mcp/server/tools/file_security_test.go
@@ -1,0 +1,137 @@
+package tools
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateUploadURLRejectsUnsafeTargets(t *testing.T) {
+	tests := []string{
+		"file:///etc/passwd",
+		"ftp://example.com/file.bin",
+		"http://127.0.0.1/file.bin",
+		"http://localhost/file.bin",
+		"http://[::1]/file.bin",
+	}
+
+	for _, rawURL := range tests {
+		t.Run(rawURL, func(t *testing.T) {
+			if _, err := validateUploadURL(rawURL); err == nil {
+				t.Fatalf("expected %q to be rejected", rawURL)
+			}
+		})
+	}
+}
+
+func TestValidateUploadURLAcceptsHTTPSURL(t *testing.T) {
+	got, err := validateUploadURL("https://example.com/path/file.bin?token=abc")
+	if err != nil {
+		t.Fatalf("expected URL to be accepted: %v", err)
+	}
+	if got.String() != "https://example.com/path/file.bin?token=abc" {
+		t.Fatalf("unexpected parsed URL: %s", got.String())
+	}
+}
+
+func TestValidateLocalPathRequiresConfiguredRoot(t *testing.T) {
+	if _, err := validateLocalPath("", "/tmp/out.bin", false); err == nil {
+		t.Fatal("expected empty local root to reject local file access")
+	}
+}
+
+func TestValidateLocalPathRejectsPathOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	if _, err := validateLocalPath(root, root+"/../outside.bin", false); err == nil {
+		t.Fatal("expected path outside root to be rejected")
+	}
+}
+
+func TestValidateLocalPathAcceptsPathInsideRoot(t *testing.T) {
+	root := t.TempDir()
+	got, err := validateLocalPath(root, root+"/nested/out.bin", false)
+	if err != nil {
+		t.Fatalf("expected path inside root to be accepted: %v", err)
+	}
+	if !strings.HasPrefix(got, root) {
+		t.Fatalf("expected %q to stay under %q", got, root)
+	}
+}
+
+func TestCopyHTTPResponseRequiresStatusOK(t *testing.T) {
+	var out strings.Builder
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       io.NopCloser(strings.NewReader("denied")),
+	}
+
+	err := copyHTTPResponse(&out, resp, 1024)
+	if err == nil {
+		t.Fatal("expected non-200 response to fail")
+	}
+	if !errors.Is(err, errUnexpectedHTTPStatus) {
+		t.Fatalf("expected errUnexpectedHTTPStatus, got %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected response body not to be copied, wrote %d bytes", out.Len())
+	}
+}
+
+func TestCopyHTTPResponseEnforcesSizeLimit(t *testing.T) {
+	var out strings.Builder
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("abcdef")),
+	}
+
+	err := copyHTTPResponse(&out, resp, 3)
+	if err == nil {
+		t.Fatal("expected oversized response to fail")
+	}
+	if !errors.Is(err, errResponseTooLarge) {
+		t.Fatalf("expected errResponseTooLarge, got %v", err)
+	}
+}
+
+func TestCopyHTTPResponseAllowsUnlimitedSizeWhenLimitIsZero(t *testing.T) {
+	var out strings.Builder
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("abcdef")),
+	}
+
+	if err := copyHTTPResponse(&out, resp, 0); err != nil {
+		t.Fatalf("expected zero limit to allow response: %v", err)
+	}
+	if out.String() != "abcdef" {
+		t.Fatalf("unexpected copied body: %q", out.String())
+	}
+}
+
+func TestMCPDefaultDownloadSizeAllowsLargeDownloads(t *testing.T) {
+	if defaultMCPDownloadMaxBytes != 0 {
+		t.Fatalf("expected default MCP download size to be unlimited, got %d", defaultMCPDownloadMaxBytes)
+	}
+}
+
+func TestMCPDefaultURLUploadSizeRemainsBounded(t *testing.T) {
+	if defaultMCPURLUploadMaxBytes <= 0 {
+		t.Fatalf("expected URL upload default size to be bounded, got %d", defaultMCPURLUploadMaxBytes)
+	}
+}
+
+func TestMCPHTTPClientUsesConfiguredTimeout(t *testing.T) {
+	client := newMCPHTTPClient(90 * time.Second)
+	if client.Timeout != 90*time.Second {
+		t.Fatalf("expected configured timeout, got %s", client.Timeout)
+	}
+}
+
+func TestMCPDefaultDownloadTimeoutAllowsLargeDownloads(t *testing.T) {
+	if defaultMCPDownloadTimeout < time.Hour {
+		t.Fatalf("expected default timeout to allow large downloads, got %s", defaultMCPDownloadTimeout)
+	}
+}

--- a/mcp/server/tools/file_security_test.go
+++ b/mcp/server/tools/file_security_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -161,6 +162,35 @@ func TestMCPHTTPClientRejectsUnsafeRedirect(t *testing.T) {
 func TestValidateResolvedIPsRejectsPrivateAddress(t *testing.T) {
 	if err := validateResolvedIPs("example.com", []net.IP{net.ParseIP("10.0.0.1")}); err == nil {
 		t.Fatal("expected private resolved IP to be rejected")
+	}
+}
+
+func TestDialResolvedIPsFallsBackToLaterAddresses(t *testing.T) {
+	ips := []net.IP{
+		net.ParseIP("203.0.113.1"),
+		net.ParseIP("203.0.113.2"),
+	}
+	var attempted []string
+	conn, err := dialResolvedIPs(context.Background(), "tcp", "example.com", "443", ips, func(ctx context.Context, network, address string) (net.Conn, error) {
+		attempted = append(attempted, address)
+		if len(attempted) == 1 {
+			return nil, errors.New("first address unreachable")
+		}
+		client, server := net.Pipe()
+		server.Close()
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("expected second address to be used: %v", err)
+	}
+	conn.Close()
+
+	want := []string{
+		net.JoinHostPort("203.0.113.1", "443"),
+		net.JoinHostPort("203.0.113.2", "443"),
+	}
+	if strings.Join(attempted, ",") != strings.Join(want, ",") {
+		t.Fatalf("unexpected dial attempts: got %v want %v", attempted, want)
 	}
 }
 

--- a/mcp/server/tools/file_security_test.go
+++ b/mcp/server/tools/file_security_test.go
@@ -146,6 +146,41 @@ func TestCopyHTTPResponseAllowsUnlimitedSizeWhenLimitIsZero(t *testing.T) {
 	}
 }
 
+func TestCopyHTTPResponseRejectsNegativeSizeLimit(t *testing.T) {
+	var out strings.Builder
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("abcdef")),
+	}
+
+	err := copyHTTPResponse(&out, resp, -1)
+	if err == nil {
+		t.Fatal("expected negative size limit to fail")
+	}
+	if !errors.Is(err, errInvalidSizeLimit) {
+		t.Fatalf("expected errInvalidSizeLimit, got %v", err)
+	}
+}
+
+func TestSaveHTTPResponseToFileRejectsNegativeSizeLimit(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target.txt")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("abcdef")),
+	}
+
+	err := saveHTTPResponseToFile(target, resp, -1)
+	if err == nil {
+		t.Fatal("expected negative size limit to fail")
+	}
+	if !errors.Is(err, errInvalidSizeLimit) {
+		t.Fatalf("expected errInvalidSizeLimit, got %v", err)
+	}
+	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+		t.Fatalf("expected target not to be created, stat err: %v", statErr)
+	}
+}
+
 func TestMCPDefaultDownloadSizeAllowsLargeDownloads(t *testing.T) {
 	if defaultMCPDownloadMaxBytes != 0 {
 		t.Fatalf("expected default MCP download size to be unlimited, got %d", defaultMCPDownloadMaxBytes)

--- a/mcp/server/tools/file_security_test.go
+++ b/mcp/server/tools/file_security_test.go
@@ -3,7 +3,11 @@ package tools
 import (
 	"errors"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -58,6 +62,22 @@ func TestValidateLocalPathAcceptsPathInsideRoot(t *testing.T) {
 	}
 	if !strings.HasPrefix(got, root) {
 		t.Fatalf("expected %q to stay under %q", got, root)
+	}
+}
+
+func TestValidateLocalPathRejectsExistingSymlinkFileOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("outside"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := validateLocalPath(root, link, false); err == nil {
+		t.Fatal("expected symlink target outside root to be rejected")
 	}
 }
 
@@ -130,8 +150,53 @@ func TestMCPHTTPClientUsesConfiguredTimeout(t *testing.T) {
 	}
 }
 
+func TestMCPHTTPClientRejectsUnsafeRedirect(t *testing.T) {
+	client := newMCPHTTPClient(90 * time.Second)
+	req := &http.Request{URL: mustParseURL(t, "http://127.0.0.1/private")}
+	if err := client.CheckRedirect(req, nil); err == nil {
+		t.Fatal("expected redirect to unsafe host to be rejected")
+	}
+}
+
+func TestValidateResolvedIPsRejectsPrivateAddress(t *testing.T) {
+	if err := validateResolvedIPs("example.com", []net.IP{net.ParseIP("10.0.0.1")}); err == nil {
+		t.Fatal("expected private resolved IP to be rejected")
+	}
+}
+
+func TestSaveHTTPResponseToFilePreservesExistingFileOnFailure(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "target.txt")
+	if err := os.WriteFile(target, []byte("old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("abcdef")),
+	}
+
+	if err := saveHTTPResponseToFile(target, resp, 3); err == nil {
+		t.Fatal("expected oversized response to fail")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("expected existing file to be preserved, got %q", string(got))
+	}
+}
+
 func TestMCPDefaultDownloadTimeoutAllowsLargeDownloads(t *testing.T) {
 	if defaultMCPDownloadTimeout < time.Hour {
 		t.Fatalf("expected default timeout to allow large downloads, got %s", defaultMCPDownloadTimeout)
 	}
+}
+
+func mustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed
 }

--- a/mcp/server/tools/file_security_test.go
+++ b/mcp/server/tools/file_security_test.go
@@ -82,6 +82,20 @@ func TestValidateLocalPathRejectsExistingSymlinkFileOutsideRoot(t *testing.T) {
 	}
 }
 
+func TestValidateLocalPathRejectsMissingPathUnderSymlinkedParentOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(link, "missing", "file.txt")
+
+	if _, err := validateLocalPath(root, target, false); err == nil {
+		t.Fatal("expected missing path below external symlink parent to be rejected")
+	}
+}
+
 func TestCopyHTTPResponseRequiresStatusOK(t *testing.T) {
 	var out strings.Builder
 	resp := &http.Response{

--- a/mcp/server/tools/offline.go
+++ b/mcp/server/tools/offline.go
@@ -11,14 +11,27 @@ import (
 
 // OfflineTools holds offline-related MCP tools
 type OfflineTools struct {
-	client *driver.Pan115Client
+	client           *driver.Pan115Client
+	allowDestructive bool
+}
+
+type OfflineToolsOption func(*OfflineTools)
+
+func WithOfflineDestructiveTools(allow bool) OfflineToolsOption {
+	return func(ot *OfflineTools) {
+		ot.allowDestructive = allow
+	}
 }
 
 // NewOfflineTools creates a new OfflineTools instance
-func NewOfflineTools(client *driver.Pan115Client) *OfflineTools {
-	return &OfflineTools{
+func NewOfflineTools(client *driver.Pan115Client, opts ...OfflineToolsOption) *OfflineTools {
+	ot := &OfflineTools{
 		client: client,
 	}
+	for _, opt := range opts {
+		opt(ot)
+	}
+	return ot
 }
 
 // ListOfflineTaskArgs defines arguments for listing offline tasks
@@ -50,20 +63,22 @@ func (ot *OfflineTools) RegisterTools(server *mcp.Server) {
 		Description: "List offline download tasks",
 	}, ot.listOfflineTasks)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "addOfflineTaskURIs",
-		Description: "Add offline tasks by download URIs, supports http, ed2k, magnet",
-	}, ot.addOfflineTaskURIs)
+	if ot.allowDestructive {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "addOfflineTaskURIs",
+			Description: "Add offline tasks by download URIs, supports http, ed2k, magnet",
+		}, ot.addOfflineTaskURIs)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "deleteOfflineTasks",
-		Description: "Delete offline tasks",
-	}, ot.deleteOfflineTasks)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "deleteOfflineTasks",
+			Description: "Delete offline tasks",
+		}, ot.deleteOfflineTasks)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "clearOfflineTasks",
-		Description: "Clear offline tasks",
-	}, ot.clearOfflineTasks)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "clearOfflineTasks",
+			Description: "Clear offline tasks",
+		}, ot.clearOfflineTasks)
+	}
 }
 
 func (ot *OfflineTools) listOfflineTasks(ctx context.Context, req *mcp.CallToolRequest, args ListOfflineTaskArgs) (*mcp.CallToolResult, any, error) {

--- a/mcp/server/tools/recycle.go
+++ b/mcp/server/tools/recycle.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/SheltonZhu/115driver/pkg/driver"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -12,21 +11,39 @@ import (
 
 // RecycleTools holds recycle bin-related MCP tools
 type RecycleTools struct {
-	client *driver.Pan115Client
+	client           *driver.Pan115Client
+	allowDestructive bool
+}
+
+type RecycleToolsOption func(*RecycleTools)
+
+func WithRecycleDestructiveTools(allow bool) RecycleToolsOption {
+	return func(rt *RecycleTools) {
+		rt.allowDestructive = allow
+	}
 }
 
 // NewRecycleTools creates a new RecycleTools instance
-func NewRecycleTools(client *driver.Pan115Client) *RecycleTools {
-	return &RecycleTools{
+func NewRecycleTools(client *driver.Pan115Client, opts ...RecycleToolsOption) *RecycleTools {
+	rt := &RecycleTools{
 		client: client,
 	}
+	for _, opt := range opts {
+		opt(rt)
+	}
+	return rt
 }
 
 // ListRecycleArgs defines arguments for listing recycle bin items
 type ListRecycleArgs struct {
-	Offset string `json:"offset" jsonschema:"offset for pagination, default is 0"`
-	Limit  string `json:"limit" jsonschema:"number of items to return, default is 40"`
+	Offset int `json:"offset" jsonschema:"offset for pagination, default is 0"`
+	Limit  int `json:"limit" jsonschema:"number of items to return, default is 40, maximum is 100"`
 }
+
+const (
+	defaultRecycleLimit = 40
+	maxRecycleLimit     = 100
+)
 
 // RevertRecycleArgs defines arguments for reverting recycle bin items
 type RevertRecycleArgs struct {
@@ -46,27 +63,21 @@ func (rt *RecycleTools) RegisterTools(server *mcp.Server) {
 		Description: "List items in the recycle bin",
 	}, rt.listRecycleBin)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "revertRecycleBin",
-		Description: "Revert items from the recycle bin",
-	}, rt.revertRecycleBin)
+	if rt.allowDestructive {
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "revertRecycleBin",
+			Description: "Revert items from the recycle bin",
+		}, rt.revertRecycleBin)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "cleanRecycleBin",
-		Description: "Clean items from the recycle bin",
-	}, rt.cleanRecycleBin)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "cleanRecycleBin",
+			Description: "Clean items from the recycle bin",
+		}, rt.cleanRecycleBin)
+	}
 }
 
 func (rt *RecycleTools) listRecycleBin(ctx context.Context, req *mcp.CallToolRequest, args ListRecycleArgs) (*mcp.CallToolResult, any, error) {
-	offset, err := strconv.Atoi(args.Offset)
-	if err != nil {
-		offset = 0
-	}
-
-	limit, err := strconv.Atoi(args.Limit)
-	if err != nil {
-		limit = 40
-	}
+	offset, limit := normalizeRecyclePagination(args.Offset, args.Limit)
 
 	items, err := rt.client.ListRecycleBin(offset, limit)
 	if err != nil {
@@ -99,6 +110,19 @@ func (rt *RecycleTools) listRecycleBin(ctx context.Context, req *mcp.CallToolReq
 			},
 		},
 	}, nil, nil
+}
+
+func normalizeRecyclePagination(offset, limit int) (int, int) {
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		limit = defaultRecycleLimit
+	}
+	if limit > maxRecycleLimit {
+		limit = maxRecycleLimit
+	}
+	return offset, limit
 }
 
 func (rt *RecycleTools) revertRecycleBin(ctx context.Context, req *mcp.CallToolRequest, args RevertRecycleArgs) (*mcp.CallToolResult, any, error) {

--- a/mcp/server/tools/recycle_test.go
+++ b/mcp/server/tools/recycle_test.go
@@ -1,0 +1,18 @@
+package tools
+
+import "testing"
+
+func TestNormalizeRecyclePaginationDefaultsAndCaps(t *testing.T) {
+	offset, limit := normalizeRecyclePagination(-1, 0)
+	if offset != 0 {
+		t.Fatalf("unexpected offset: %d", offset)
+	}
+	if limit != defaultRecycleLimit {
+		t.Fatalf("expected default limit %d, got %d", defaultRecycleLimit, limit)
+	}
+
+	_, limit = normalizeRecyclePagination(0, maxRecycleLimit+1)
+	if limit != maxRecycleLimit {
+		t.Fatalf("expected max limit %d, got %d", maxRecycleLimit, limit)
+	}
+}


### PR DESCRIPTION
## Summary
- validate MCP cookies and restrict local filesystem access behind --local-root
- add configurable timeout and size-limit controls for MCP/CLI transfers, with download_file unlimited by default
- require --allow-destructive-tools before MCP registers cloud-mutating tools
- bound MCP and CLI directory/recycle listing defaults and add safer CLI rm/download path behavior

## Documentation
- README documents CLI ls pagination, rm --force behavior, MCP timeout/size flags, and destructive tool gating
- mcp/mcp_example.md documents local-root, transfer controls, destructive tools, and updated recycle pagination types

## Verification
- go test ./mcp/... ./cli/...
- go build ./mcp ./cli ./cmd/115driver

Note: go test ./... still requires valid 115 credentials for existing pkg/driver online tests.