### PR TITLE
feat(offline): add configurable default offline save directory

### DIFF
--- a/cli/cmd/offline.go
+++ b/cli/cmd/offline.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/SheltonZhu/115driver/cli/internal/auth"
 	"github.com/SheltonZhu/115driver/cli/internal/output"
 	"github.com/SheltonZhu/115driver/cli/internal/resolver"
 	"github.com/SheltonZhu/115driver/pkg/driver"
@@ -24,12 +25,25 @@ var offlineAddCmd = &cobra.Command{
 		url := args[0]
 
 		saveDirID := resolver.RootID
+		saveDirName := ""
 		if offlineSaveDir != "" {
+			// -d flag takes priority
 			id, err := resolver.ResolveDir(client, offlineSaveDir)
 			if err != nil {
 				return &exitError{code: output.ExitNotFound, msg: fmt.Sprintf("Save directory not found: %s", offlineSaveDir)}
 			}
 			saveDirID = id
+			saveDirName = offlineSaveDir
+		} else {
+			// Try config default
+			if cfgDir := auth.ReadProfileConfig(configPath, profile, "default_offline_save_dir"); cfgDir != "" {
+				id, err := resolver.ResolveDir(client, cfgDir)
+				if err != nil {
+					return &exitError{code: output.ExitNotFound, msg: fmt.Sprintf("Save directory not found: %s (from config default_offline_save_dir)", cfgDir)}
+				}
+				saveDirID = id
+				saveDirName = cfgDir
+			}
 		}
 
 		hashes, err := client.AddOfflineTaskURIs([]string{url}, saveDirID)
@@ -40,7 +54,7 @@ var offlineAddCmd = &cobra.Command{
 		printer.PrintSuccess(map[string]interface{}{
 			"url":      url,
 			"hashes":   hashes,
-			"save_dir": offlineSaveDir,
+			"save_dir": saveDirName,
 		})
 		if !jsonOutput {
 			fmt.Printf("Offline task added: %s\n", url)

--- a/cli/internal/auth/auth.go
+++ b/cli/internal/auth/auth.go
@@ -134,3 +134,36 @@ func SaveCredential(configPath, profile, cookie string) error {
 	}
 	return os.Chmod(path, 0600)
 }
+
+// ReadProfileConfig reads a config value from the specified profile section.
+// Returns empty string if the key is not set.
+func ReadProfileConfig(configPath, profile, key string) string {
+	path := configPath
+	if path == "" {
+		if envPath := os.Getenv(EnvConfig); envPath != "" {
+			path = envPath
+		} else {
+			home, _ := os.UserHomeDir()
+			path = filepath.Join(home, DefaultConfigDir, DefaultConfigFile)
+		}
+	}
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	if err := v.ReadInConfig(); err != nil {
+		return ""
+	}
+
+	prof := profile
+	if prof == "" {
+		prof = ResolveProfile(profile)
+	}
+	if prof == "" {
+		prof = v.GetString("default_profile")
+	}
+	if prof == "" {
+		prof = DefaultProfile
+	}
+
+	return v.GetString("profiles." + prof + "." + key)
+}

--- a/cli/internal/auth/auth_test.go
+++ b/cli/internal/auth/auth_test.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+	return path
+}
+
+func TestReadProfileConfig_KeyExists(t *testing.T) {
+	configPath := writeTestConfig(t, `
+default_profile = "main"
+
+[profiles.main]
+cookie = "UID=123;CID=abc"
+default_offline_save_dir = "123456"
+
+[profiles.work]
+cookie = "UID=456"
+default_offline_save_dir = "789012"
+`)
+	got := ReadProfileConfig(configPath, "main", "default_offline_save_dir")
+	if got != "123456" {
+		t.Fatalf("expected '123456', got '%s'", got)
+	}
+}
+
+func TestReadProfileConfig_KeyMissing(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.main]
+cookie = "UID=123;CID=abc"
+`)
+	got := ReadProfileConfig(configPath, "main", "nonexistent_key")
+	if got != "" {
+		t.Fatalf("expected empty string, got '%s'", got)
+	}
+}
+
+func TestReadProfileConfig_ConfigNotExist(t *testing.T) {
+	got := ReadProfileConfig("/nonexistent/path/config.toml", "main", "any_key")
+	if got != "" {
+		t.Fatalf("expected empty string for missing config, got '%s'", got)
+	}
+}
+
+func TestReadProfileConfig_CustomProfile(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.personal]
+cookie = "UID=789"
+default_offline_save_dir = "personal_dir"
+
+[profiles.main]
+default_offline_save_dir = "default_dir"
+`)
+	got := ReadProfileConfig(configPath, "personal", "default_offline_save_dir")
+	if got != "personal_dir" {
+		t.Fatalf("expected 'personal_dir', got '%s'", got)
+	}
+}
+
+func TestReadProfileConfig_EmptyProfileFallsBackToHardcodedDefault(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.main]
+default_offline_save_dir = "main_dir"
+
+[profiles.work]
+default_offline_save_dir = "work_dir"
+`)
+	got := ReadProfileConfig(configPath, "", "default_offline_save_dir")
+	if got != "main_dir" {
+		t.Fatalf("expected 'main_dir' (hardcoded default), got '%s'", got)
+	}
+}
+
+func TestReadProfileConfig_EmptyProfileNoDefault(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.main]
+default_offline_save_dir = "main_dir"
+`)
+	got := ReadProfileConfig(configPath, "", "default_offline_save_dir")
+	if got != "main_dir" {
+		t.Fatalf("expected 'main_dir' (hardcoded default), got '%s'", got)
+	}
+}


### PR DESCRIPTION
## Summary

Add a new config option `default_offline_save_dir` under the profile section in `~/.115driver/config.toml`, allowing users to set a persistent default directory for offline download tasks. **Both CLI and MCP server support this feature.**

## Motivation

Currently, `115driver offline add` always saves to the root directory unless the `-d` flag is explicitly passed each time. There is no way to set a persistent default, which is inconvenient for users who always want downloads to go to a specific folder (e.g., "云下载").

## Changes (5 files, +143/-12)

### CLI side

#### `cli/internal/auth/auth.go`
- Added `ReadProfileConfig(configPath, profile, key string) string` — a general-purpose helper that reads an arbitrary config key from a specific profile section.

#### `cli/cmd/offline.go`
- When `offline add` is called without the `-d` flag, it reads `default_offline_save_dir` from config via `auth.ReadProfileConfig`.
- If the config value is set and non-empty, it resolves that directory and saves tasks there.
- Falls back to root directory if config is unset (original behavior).
- The `-d` flag always takes priority over config.
- Fixed `save_dir` output to reflect actual directory name.

### MCP side

#### `mcp/main.go`
- Added `--profile` and `--config` CLI flags.
- Added `resolveDefaultSaveDir()` to read `default_offline_save_dir` from config.

#### `mcp/server/server.go`
- Added `defaultSaveDir` field and `WithDefaultSaveDir()` method.

#### `mcp/server/tools/offline.go`
- `NewOfflineTools` now accepts `defaultSaveDir` parameter.
- When `save_dir_id` is empty and config has a default, resolves directory name to ID via `DirName2CID`.

## Behavior Matrix

| Scenario | CLI | MCP |
|---|---|---|
| No `-d` / no `save_dir_id`, config has `default_offline_save_dir` | Saves to config dir | Saves to config dir |
| No `-d` / no `save_dir_id`, config is empty | Root directory | Root directory |
| `-d` / `save_dir_id` specified | Flag always wins | Argument always wins |

## Configuration Example

```toml
[profiles.main]
cookie = "UID=..."
default_offline_save_dir = "云下载"
```

## MCP server startup

```bash
115driver-mcp --cookie="UID=...;CID=...;SEID=..." --profile main
```