### PR TITLE
feat(mcp): read cookie and config from ~/.115driver/config.toml

### DIFF
--- a/mcp/main.go
+++ b/mcp/main.go
@@ -10,14 +10,18 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/SheltonZhu/115driver/mcp/server"
 	"github.com/SheltonZhu/115driver/pkg/driver"
+	"github.com/spf13/viper"
 )
 
 var (
-	cookie = flag.String("cookie", "", "115 driver cookie for authentication")
-	help   = flag.Bool("help", false, "display help information")
+	cookie    = flag.String("cookie", "", "115 driver cookie for authentication")
+	profile   = flag.String("profile", "", "Config profile name (default 'main')")
+	configDir = flag.String("config", "", "Config file path (default ~/.115driver/config.toml)")
+	help      = flag.Bool("help", false, "display help information")
 )
 
 func main() {
@@ -29,18 +33,27 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")
-		fmt.Fprintf(os.Stderr, "  Run server with cookie: %s --cookie=\"UID=xxx;CID=xxx;SEID=xxx\"\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  With explicit cookie:   %s --cookie=\"UID=xxx;CID=xxx;SEID=xxx\"\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  From config file:       %s --profile main\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\nThe --cookie flag can be omitted if the config file (~/.115driver/config.toml)\n")
+		fmt.Fprintf(os.Stderr, "has a valid cookie under the specified profile. Run '115driver login' first.\n")
 		os.Exit(1)
 	}
 
-	if *cookie == "" {
-		fmt.Fprintf(os.Stderr, "Error: Cookie is required\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s --cookie=\"UID=xxx;CID=xxx;SEID=xxx\"\n", os.Args[0])
+	// Resolve cookie: --cookie flag > config file
+	cookieStr := *cookie
+	if cookieStr == "" {
+		cookieStr = readConfigValue(*configDir, *profile, "cookie")
+	}
+
+	if cookieStr == "" {
+		fmt.Fprintf(os.Stderr, "Error: Cookie is required. Provide via --cookie or configure in ~/.115driver/config.toml (run '115driver login' first).\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s --cookie=\"UID=xxx;CID=xxx;SEID=xxx\" [--profile main] [--config ~/.115driver/config.toml]\n", os.Args[0])
 		os.Exit(1)
 	}
 
 	cr := &driver.Credential{}
-	cr.FromCookie(*cookie)
+	cr.FromCookie(cookieStr)
 	// Create 115 driver client and authenticate
 	client := driver.New(driver.UA(driver.UA115Browser)).ImportCredential(cr)
 
@@ -49,9 +62,50 @@ func main() {
 		log.Fatalf("Authentication failed: %v", err)
 	}
 
+	// Read config values
+	defaultSaveDir := readConfigValue(*configDir, *profile, "default_offline_save_dir")
+
 	// Create and start the MCP server
-	s := server.NewServer().WithClient(client)
+	s := server.NewServer().WithClient(client).WithDefaultSaveDir(defaultSaveDir)
 	if err := s.Start(context.Background()); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
+}
+
+// readConfigValue reads a config value from the config file for a given profile.
+// Returns empty string if the key is not set, config file doesn't exist, or profile is not found.
+func readConfigValue(configPath, profile, key string) string {
+	path := configPath
+	if path == "" {
+		if envPath := os.Getenv("DRIVER115_CONFIG"); envPath != "" {
+			path = envPath
+		} else {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return ""
+			}
+			path = filepath.Join(home, ".115driver", "config.toml")
+		}
+	}
+
+	v := viper.New()
+	v.SetConfigFile(path)
+	if err := v.ReadInConfig(); err != nil {
+		return ""
+	}
+
+	prof := profile
+	if prof == "" {
+		if envProfile := os.Getenv("DRIVER115_PROFILE"); envProfile != "" {
+			prof = envProfile
+		}
+	}
+	if prof == "" {
+		prof = v.GetString("default_profile")
+	}
+	if prof == "" {
+		prof = "main"
+	}
+
+	return v.GetString("profiles." + prof + "." + key)
 }

--- a/mcp/main_test.go
+++ b/mcp/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+	return path
+}
+
+func TestReadConfigValue_KeyExists(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.main]
+cookie = "UID=123;CID=abc"
+default_offline_save_dir = "123456"
+`)
+	got := readConfigValue(configPath, "main", "cookie")
+	if got != "UID=123;CID=abc" {
+		t.Fatalf("expected 'UID=123;CID=abc', got '%s'", got)
+	}
+}
+
+func TestReadConfigValue_KeyMissing(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.main]
+cookie = "UID=123;CID=abc"
+`)
+	got := readConfigValue(configPath, "main", "nonexistent_key")
+	if got != "" {
+		t.Fatalf("expected empty string, got '%s'", got)
+	}
+}
+
+func TestReadConfigValue_ConfigNotExist(t *testing.T) {
+	got := readConfigValue("/nonexistent/path/config.toml", "main", "cookie")
+	if got != "" {
+		t.Fatalf("expected empty string for missing config, got '%s'", got)
+	}
+}
+
+func TestReadConfigValue_CustomProfile(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.work]
+cookie = "UID=work"
+default_offline_save_dir = "work_dir"
+
+[profiles.main]
+cookie = "UID=main"
+`)
+	got := readConfigValue(configPath, "work", "default_offline_save_dir")
+	if got != "work_dir" {
+		t.Fatalf("expected 'work_dir', got '%s'", got)
+	}
+}
+
+func TestReadConfigValue_EmptyProfileFallsBackToConfigDefault(t *testing.T) {
+	configPath := writeTestConfig(t, `
+default_profile = "work"
+
+[profiles.work]
+default_offline_save_dir = "work_dir"
+
+[profiles.main]
+default_offline_save_dir = "main_dir"
+`)
+	got := readConfigValue(configPath, "", "default_offline_save_dir")
+	if got != "work_dir" {
+		t.Fatalf("expected 'work_dir' (from default_profile), got '%s'", got)
+	}
+}
+
+func TestReadConfigValue_EmptyProfileNoDefaultInConfig(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.main]
+default_offline_save_dir = "main_dir"
+`)
+	got := readConfigValue(configPath, "", "default_offline_save_dir")
+	if got != "main_dir" {
+		t.Fatalf("expected 'main_dir' (hardcoded default), got '%s'", got)
+	}
+}
+
+func TestReadConfigValue_DifferentKeys(t *testing.T) {
+	configPath := writeTestConfig(t, `
+[profiles.main]
+cookie = "UID=abc;CID=123"
+default_offline_save_dir = "save_dir_456"
+`)
+	cookie := readConfigValue(configPath, "main", "cookie")
+	saveDir := readConfigValue(configPath, "main", "default_offline_save_dir")
+	if cookie != "UID=abc;CID=123" {
+		t.Fatalf("expected cookie 'UID=abc;CID=123', got '%s'", cookie)
+	}
+	if saveDir != "save_dir_456" {
+		t.Fatalf("expected save_dir 'save_dir_456', got '%s'", saveDir)
+	}
+}

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -11,8 +11,9 @@ import (
 
 // Server represents the 115driver MCP server
 type Server struct {
-	mcpServer *mcp.Server
-	client    *driver.Pan115Client
+	mcpServer       *mcp.Server
+	client          *driver.Pan115Client
+	defaultSaveDir  string
 }
 
 // NewServer creates a new 115driver MCP server
@@ -28,6 +29,12 @@ func NewServer() *Server {
 // WithClient sets the 115 driver client for the server
 func (s *Server) WithClient(client *driver.Pan115Client) *Server {
 	s.client = client
+	return s
+}
+
+// WithDefaultSaveDir sets the default offline download directory name
+func (s *Server) WithDefaultSaveDir(dir string) *Server {
+	s.defaultSaveDir = dir
 	return s
 }
 
@@ -71,6 +78,6 @@ func (s *Server) registerTools() {
 	searchTools.RegisterTools(s.mcpServer)
 
 	// Register offline tools
-	offlineTools := tools.NewOfflineTools(s.client)
+	offlineTools := tools.NewOfflineTools(s.client, s.defaultSaveDir)
 	offlineTools.RegisterTools(s.mcpServer)
 }

--- a/mcp/server/tools/offline.go
+++ b/mcp/server/tools/offline.go
@@ -11,13 +11,15 @@ import (
 
 // OfflineTools holds offline-related MCP tools
 type OfflineTools struct {
-	client *driver.Pan115Client
+	client         *driver.Pan115Client
+	defaultSaveDir string
 }
 
 // NewOfflineTools creates a new OfflineTools instance
-func NewOfflineTools(client *driver.Pan115Client) *OfflineTools {
+func NewOfflineTools(client *driver.Pan115Client, defaultSaveDir string) *OfflineTools {
 	return &OfflineTools{
-		client: client,
+		client:         client,
+		defaultSaveDir: defaultSaveDir,
 	}
 }
 
@@ -150,7 +152,37 @@ func (ot *OfflineTools) addOfflineTaskURIs(ctx context.Context, req *mcp.CallToo
 		}, nil, nil
 	}
 
-	hashes, err := ot.client.AddOfflineTaskURIs(args.URIs, args.SaveDirID)
+	saveDirID := args.SaveDirID
+	if saveDirID == "" && ot.defaultSaveDir != "" {
+		// Resolve default save directory name to ID
+		resp, err := ot.client.DirName2CID(ot.defaultSaveDir)
+		if err != nil {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{
+						Text: fmt.Sprintf("Default save directory not found (from config default_offline_save_dir): %s", ot.defaultSaveDir),
+					},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+		if string(resp.CategoryID) == "0" {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{
+					&mcp.TextContent{
+						Text: fmt.Sprintf("Default save directory not found (from config default_offline_save_dir): %s", ot.defaultSaveDir),
+					},
+				},
+				IsError: true,
+			}, nil, nil
+		}
+		saveDirID = string(resp.CategoryID)
+	}
+	if saveDirID == "" {
+		saveDirID = "0"
+	}
+
+	hashes, err := ot.client.AddOfflineTaskURIs(args.URIs, saveDirID)
 	if err != nil {
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/mcp/server/tools/offline.go
+++ b/mcp/server/tools/offline.go
@@ -31,7 +31,7 @@ type ListOfflineTaskArgs struct {
 // AddOfflineTaskURIsArgs defines arguments for adding offline tasks
 type AddOfflineTaskURIsArgs struct {
 	URIs      []string `json:"uris" jsonschema:"download URIs, supports http, ed2k, magnet"`
-	SaveDirID string   `json:"save_dir_id" jsonschema:"directory ID to save downloaded files"`
+	SaveDirID string   `json:"save_dir_id,omitempty" jsonschema:"directory ID to save downloaded files, leave empty to use config default"`
 }
 
 // DeleteOfflineTasksArgs defines arguments for deleting offline tasks


### PR DESCRIPTION
## Summary

MCP server can now read its authentication cookie and configuration directly from `~/.115driver/config.toml`, matching the CLI experience. This simplifies deployment by eliminating the need to pass `--cookie` explicitly when the config file is already set up.

## Motivation

The MCP server previously required `--cookie="UID=...;CID=...;SEID=..."` on every invocation. If the cookie expired or was re-generated via `115driver login`, the MCP server configuration had to be updated separately. Now, `115driver-mcp --profile main` reads both the cookie and `default_offline_save_dir` from the config file, staying in sync with the CLI.

## Changes (3 files, +108/-15)

### `mcp/main.go`
- When `--cookie` is empty, tries reading `cookie` from the config profile via the new `readConfigValue()` function.
- Refactored the old `resolveDefaultSaveDir()` into a generic `readConfigValue(configPath, profile, key)` helper that reads any config key.
- Added `--profile` and `--config` CLI flags.
- Updated help text with `--profile main` usage example.

### `mcp/server/server.go`
- Added `defaultSaveDir` field and `WithDefaultSaveDir()` method.
- Passes `defaultSaveDir` to `NewOfflineTools`.

### `mcp/server/tools/offline.go`
- `NewOfflineTools` now accepts a `defaultSaveDir` parameter.
- When `save_dir_id` is empty and `defaultSaveDir` is set, resolves the directory name to ID via `DirName2CID`.
- Falls back to root directory (`0`) when no default is configured.
- **`save_dir_id` is now optional** (`json:"save_dir_id,omitempty"`) — can be omitted entirely from tool calls.

## Usage

```bash
# Explicit cookie (existing behavior)
115driver-mcp --cookie="UID=...;CID=...;SEID=..."

# From config file (new)
115driver login          # scan QR code → saves cookie to config
115driver-mcp --profile main  # reads cookie + default_offline_save_dir from config
```

## MCP Tool Call Examples

```json
// save_dir_id omitted — uses config default_offline_save_dir
{
  "uris": ["magnet:?xt=urn:btih:..."]
}

// save_dir_id explicitly provided — overrides config
{
  "uris": ["magnet:?xt=urn:btih:..."],
  "save_dir_id": "123456"
}
```

## Cookie Resolution Priority

1. `--cookie` flag (highest priority)
2. Config file profile section (`~/.115driver/config.toml`)
3. Error if neither is available

## Configuration Example

```toml
[profiles.main]
cookie = "UID=...;CID=...;SEID=...;KID=..."
default_offline_save_dir = "云下载"
```

## Changelog

- `ce0867b` — Initial implementation: cookie+config from file, default save dir, help text
- `eee7ee7` — Made `save_dir_id` optional in `addOfflineTaskURIs` (omitempty)