### PR TITLE
fix: handle 115 API response format changes for imei_info and download url

### DIFF
--- a/internal/accountinfo/accountinfo.go
+++ b/internal/accountinfo/accountinfo.go
@@ -1,12 +1,16 @@
 package accountinfo
 
-import "github.com/SheltonZhu/115driver/pkg/driver"
+import (
+	"encoding/json"
+
+	"github.com/SheltonZhu/115driver/pkg/driver"
+)
 
 type AccountInfo struct {
 	User         User                    `json:"user"`
 	Space        Space                   `json:"space"`
 	LoginDevices driver.LoginDevicesInfo `json:"login_devices"`
-	ImeiInfo     bool                    `json:"imei_info"`
+	ImeiInfo     json.RawMessage         `json:"imei_info"`
 }
 
 type User struct {

--- a/internal/accountinfo/accountinfo_test.go
+++ b/internal/accountinfo/accountinfo_test.go
@@ -1,6 +1,7 @@
 package accountinfo
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/SheltonZhu/115driver/pkg/driver"
@@ -26,7 +27,7 @@ func TestFromDriverDataMapsAccountInfo(t *testing.T) {
 				{Device: "Browser", IsCurrent: 1},
 			},
 		},
-		ImeiInfo: true,
+		ImeiInfo: json.RawMessage("true"),
 	}
 
 	got := FromDriverData(user, info)
@@ -41,5 +42,5 @@ func TestFromDriverDataMapsAccountInfo(t *testing.T) {
 	assert.Equal(t, int64(750), got.Space.Used.Size)
 	assert.Equal(t, "127.0.0.1", got.LoginDevices.Last.IP)
 	assert.Len(t, got.LoginDevices.List, 1)
-	assert.True(t, got.ImeiInfo)
+	assert.Equal(t, json.RawMessage("true"), got.ImeiInfo)
 }

--- a/pkg/driver/download.go
+++ b/pkg/driver/download.go
@@ -15,6 +15,7 @@ type FileDownloadUrl struct {
 	Client float64 `json:"client"`
 	OSSID  string  `json:"oss_id"`
 	Url    string  `json:"url"`
+	Valid  bool    `json:"-"` // false when API returned false/null
 }
 
 // UnmarshalJSON handles both object and bool (false) responses from the API.
@@ -31,6 +32,7 @@ func (f *FileDownloadUrl) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	*f = FileDownloadUrl(a)
+	f.Valid = true
 	return nil
 }
 

--- a/pkg/driver/download.go
+++ b/pkg/driver/download.go
@@ -17,6 +17,23 @@ type FileDownloadUrl struct {
 	Url    string  `json:"url"`
 }
 
+// UnmarshalJSON handles both object and bool (false) responses from the API.
+func (f *FileDownloadUrl) UnmarshalJSON(b []byte) error {
+	// Handle false/null/empty cases
+	if len(b) == 0 || string(b) == "false" || string(b) == "null" {
+		*f = FileDownloadUrl{}
+		return nil
+	}
+	// Handle object case
+	type alias FileDownloadUrl
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*f = FileDownloadUrl(a)
+	return nil
+}
+
 type DownloadInfo struct {
 	FileName string          `json:"file_name"`
 	FileSize StringInt64     `json:"file_size"`

--- a/pkg/driver/info.go
+++ b/pkg/driver/info.go
@@ -30,7 +30,7 @@ type InfoResponse struct {
 type InfoData struct {
 	SpaceInfo        SpaceInfo        `json:"space_info"`
 	LoginDevicesInfo LoginDevicesInfo `json:"login_devices_info"`
-	ImeiInfo         bool             `json:"imei_info"`
+	ImeiInfo         json.RawMessage  `json:"imei_info"`
 }
 
 type TotalSize struct {


### PR DESCRIPTION
## Summary

Fixes JSON deserialization errors in `getAccountInfo` and `get_download_info` caused by upstream 115 API response format changes.

## Root Cause

The 115 API changed two response fields:

### 1. `data.imei_info` (affects `getAccountInfo`)
- **Old format**: `"imei_info": false` (bool)
- **New format**: an object with device IMEI info

### 2. `DownloadInfo.url` (affects `get_download_info`)
- **Old format**: `"url": { "url": "https://...", "client": 1, "oss_id": "..." }` (object)
- **New format**: `"url": false` (bool)

## Changes (4 files, +27/-5)

### `pkg/driver/info.go`
- `ImeiInfo` field type changed from `bool` to `json.RawMessage`, accepting any valid JSON value (bool, object, etc.)

### `pkg/driver/download.go`
- Added custom `UnmarshalJSON` on `FileDownloadUrl` that gracefully handles `false`/`null` values by returning an empty struct, while retaining the normal object deserialization for the old format.

### `internal/accountinfo/accountinfo.go`
- Updated `ImeiInfo` type to `json.RawMessage` to match the driver package change.

### `internal/accountinfo/accountinfo_test.go`
- Updated test to use `json.RawMessage("true")` instead of bare `true`.

## Testing

- All existing unit tests pass (`go test ./pkg/driver/ ./internal/accountinfo/`).
- Both CLI (`115driver info --json`) and MCP (`getAccountInfo`) now return full account info successfully.