### PR TITLE
fix: handle 115 API returning string file_id in FileParentInfo

### DIFF
--- a/pkg/driver/op.go
+++ b/pkg/driver/op.go
@@ -150,7 +150,7 @@ func (c *Pan115Client) Stat(fileID string) (*FileStatInfo, error) {
 	info.Parents = make([]*DirInfo, len(result.Paths))
 	for i, path := range result.Paths {
 		info.Parents[i] = &DirInfo{
-			ID:   strconv.Itoa(path.FileID),
+			ID:   strconv.FormatInt(int64(path.FileID), 10),
 			Name: path.FileName,
 		}
 	}

--- a/pkg/driver/response.go
+++ b/pkg/driver/response.go
@@ -276,8 +276,8 @@ type FileStatResponse struct {
 	Paths       []*FileParentInfo `json:"paths"`
 }
 type FileParentInfo struct {
-	FileID   int    `json:"file_id"`
-	FileName string `json:"file_name"`
+	FileID   StringInt `json:"file_id"`
+	FileName string    `json:"file_name"`
 }
 
 func (r *FileStatResponse) Err(respBody ...string) error {


### PR DESCRIPTION
## Summary

Fixes JSON deserialization errors in the `Stat` endpoint and all CLI path-resolution commands (`ls`, `stat`, `upload`) caused by upstream 115 API response format changes.

## Root Cause

The 115 API changed the type of `file_id` inside the `paths` array (returned by the file-stat endpoint) from a **number** to a **string**. The Go struct field was typed as `int`, so `json.Unmarshal` failed with:

```
json: cannot unmarshal string into Go struct field FileParentInfo.paths.file_id of type int
```

This crash made every path-based operation (`/影视娱乐/动漫/...`) fail, since `Stat` populates the parent directory chain from `paths`.

## Changes (2 files, +3/-3)

### `pkg/driver/response.go`

- `FileParentInfo.FileID` field type changed from `int` to `StringInt`, which already has a custom `UnmarshalJSON` that accepts both old (number) and new (string) formats.

### `pkg/driver/op.go`

- Updated the conversion in `Stat()` from `strconv.Itoa(path.FileID)` to `strconv.FormatInt(int64(path.FileID), 10)` to match the new `StringInt` type.

## Testing

- Verified `go vet ./pkg/driver/ ./cli/...` passes cleanly.
- Verified CLI path resolution works against live 115 API: `115driver stat "/影视娱乐/动漫/xxxx/xxxxxxx上篇"` now returns the expected parent-directory chain.
<img width="891" height="662" alt="image" src="https://github.com/user-attachments/assets/1790d0de-6802-47ed-8855-d45f0fbd6318" />

- Verified a 42GB file upload via CLI path resolution succeeds end-to-end.