### PR TITLE
feat(driver): expose ShareFile.Duration (play_long)

### DIFF
--- a/pkg/driver/response.go
+++ b/pkg/driver/response.go
@@ -393,6 +393,7 @@ type ShareFile struct {
 	UpdateTime string       `json:"t"`
 	IsFile     int          `json:"fc"`
 	ParentID   string       `json:"pid"`
+	Duration   int          `json:"play_long"`
 	// Ns          string       `json:"ns"`
 	// D           int          `json:"d"`
 	// C           int          `json:"c"`


### PR DESCRIPTION
## Problem

115 share file listings include a `play_long` field with the media play duration, but `ShareFile` does not expose it, so consumers have to issue extra requests to learn a share item's video duration.

## Change

Add `Duration int `json:"play_long"`` to `ShareFile`.

This field has been running in production in the [power721/115driver](https://github.com/power721/115driver) fork.